### PR TITLE
Add missing dependency on `syntax-classes-lib`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -5,6 +5,7 @@
 (define deps '("base"
                "version-case"
                "ee-lib"
+               "syntax-classes-lib"
                "paren-shape"
                "rackunit-lib"))
 (define build-deps '("racket-doc" "scribble-lib" "drracket"))


### PR DESCRIPTION
The package server reports this missing dependency:

From https://pkg-build.racket-lang.org/server/built/deps/syntax-spec-v1.txt

```
raco setup: --- checking package dependencies ---                  [4:22:14]
raco setup: found undeclared dependency:
raco setup:   mode: run
raco setup:   for package: "syntax-spec-v1"
raco setup:   on package: "syntax-classes-lib"
raco setup:   dependent source: /home/root//zo/home/root/user/.local/share/racket/8.11/pkgs/syntax-spec-v1/private/syntax/compile/compiled/binding-spec_rkt.zo
raco setup:   used module: (lib "syntax/parse/class/paren-shape.rkt")
raco setup: --- summary of package problems ---                    [4:22:16]
raco setup: undeclared dependency detected
raco setup:   for package: "syntax-spec-v1"
raco setup:   on package:
raco setup:    "syntax-classes-lib"
```
