### PR TITLE
support application reference compilers

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -9,6 +9,8 @@
           mutable-reference-compiler
           immutable-reference-compiler
 
+          make-variable-like-reference-compiler
+
           define-persistent-symbol-table
           define-local-symbol-table
           syntax-datum?

--- a/tests/dsls/miniclass/class.rkt
+++ b/tests/dsls/miniclass/class.rkt
@@ -128,19 +128,21 @@
              cls))]))
 
   (define method-reference-compiler
-    (make-variable-like-transformer (syntax-parser
-                                      [name:id
-                                       #'(lambda args (send this name . args))])))
+    (make-variable-like-reference-compiler
+     (syntax-parser
+       [name:id
+        #'(lambda args (send this name . args))])))
 
   (define field-reference-compiler
-    (make-variable-like-transformer (syntax-parser
-                                      [name:id
-                                       (let ([idx (symbol-table-ref field-index-table #'name)])
-                                         #`(vector-ref (object-fields this) #,idx))])
-                                    (syntax-parser
-                                      [(_ name:id rhs)
-                                       (let ([idx (symbol-table-ref field-index-table #'name)])
-                                         #`(vector-set! (object-fields this) #,idx rhs))])))
+    (make-variable-like-reference-compiler
+     (syntax-parser
+       [name:id
+        (let ([idx (symbol-table-ref field-index-table #'name)])
+          #`(vector-ref (object-fields this) #,idx))])
+     (syntax-parser
+       [(_ name:id rhs)
+        (let ([idx (symbol-table-ref field-index-table #'name)])
+          #`(vector-set! (object-fields this) #,idx rhs))])))
 
   #;((listof identifier?) -> void?)
   ;; If there are (symbolically) duplicate method names, error

--- a/tests/reference-compiler-with-application.rkt
+++ b/tests/reference-compiler-with-application.rkt
@@ -9,35 +9,51 @@
          rackunit
          syntax/macro-testing)
 
+(begin-for-syntax
+  ; maps each identifier to the number it's bound to
+  (define-persistent-symbol-table number-vars))
+
 (syntax-spec
  (binding-class mutable-var)
  (binding-class immutable-var)
  (binding-class weird-var)
+ (binding-class number-var)
  (nonterminal expr
               (mutable-let ([x:mutable-var e:racket-expr]) body:racket-expr)
               #:binding {(bind x) body}
               (immutable-let ([x:immutable-var e:racket-expr]) body:racket-expr)
               #:binding {(bind x) body}
               (weird-let ([x:weird-var e:racket-expr]) body:racket-expr)
+              #:binding {(bind x) body}
+              (number-let ([x:number-var n:number]) body:racket-expr)
               #:binding {(bind x) body})
 
  (host-interface/expression
   (expression e:expr)
-  #'(with-reference-compilers ([weird-var (syntax-parser [x:id #'x]
-                                                   [(x:id . args)
-                                                    #`(list x `#,(length (syntax-e #'args)))])]
+  #'(with-reference-compilers ([weird-var (syntax-parser
+                                            [x:id #'x]
+                                            [(x:id . args)
+                                             #`(list x `#,(length (syntax-e #'args)))])]
+                               [number-var (make-variable-like-reference-compiler
+                                            (lambda (x)
+                                              #`#,(symbol-table-ref number-vars x)))]
                                [mutable-var mutable-reference-compiler]
                                [immutable-var immutable-reference-compiler])
       (compile-expr e))))
 
 (define-syntax compile-expr
   (syntax-parser
+    [(_ ((~datum number-let) ([x n:number]) body))
+     (symbol-table-set! number-vars #'x (syntax-e #'n))
+     #'body]
     [(_ (_ ([x e]) body)) #'(let ([x e]) body)]))
 
 (check-equal? (expression (weird-let ([x 'foo]) x)) 'foo)
 (check-equal? (expression (weird-let ([x 'foo]) (x))) '(foo 0))
 (check-equal? (expression (weird-let ([x 'foo]) (x 1))) '(foo 1))
 (check-equal? (expression (weird-let ([x 'foo]) (x 1 2 3))) '(foo 3))
+
+(check-equal? (expression (number-let ([x 2]) x)) 2)
 
 (check-equal? (expression (immutable-let ([x (lambda (y) y)]) (x 2))) 2)
 (check-equal? (expression (mutable-let ([x (lambda (y) y)]) (x 2))) 2)

--- a/tests/reference-compiler-with-application.rkt
+++ b/tests/reference-compiler-with-application.rkt
@@ -1,0 +1,43 @@
+#lang racket/base
+
+; test the behavior of a reference compiler that cares about the application case
+; instead of just being a variable-like transformer.
+; also make sure variable-like reference compilers support application
+
+(require "../main.rkt"
+         (for-syntax syntax/parse racket/base)
+         rackunit
+         syntax/macro-testing)
+
+(syntax-spec
+ (binding-class mutable-var)
+ (binding-class immutable-var)
+ (binding-class weird-var)
+ (nonterminal expr
+              (mutable-let ([x:mutable-var e:racket-expr]) body:racket-expr)
+              #:binding {(bind x) body}
+              (immutable-let ([x:immutable-var e:racket-expr]) body:racket-expr)
+              #:binding {(bind x) body}
+              (weird-let ([x:weird-var e:racket-expr]) body:racket-expr)
+              #:binding {(bind x) body})
+
+ (host-interface/expression
+  (expression e:expr)
+  #'(with-reference-compilers ([weird-var (syntax-parser [x:id #'x]
+                                                   [(x:id . args)
+                                                    #`(list x `#,(length (syntax-e #'args)))])]
+                               [mutable-var mutable-reference-compiler]
+                               [immutable-var immutable-reference-compiler])
+      (compile-expr e))))
+
+(define-syntax compile-expr
+  (syntax-parser
+    [(_ (_ ([x e]) body)) #'(let ([x e]) body)]))
+
+(check-equal? (expression (weird-let ([x 'foo]) x)) 'foo)
+(check-equal? (expression (weird-let ([x 'foo]) (x))) '(foo 0))
+(check-equal? (expression (weird-let ([x 'foo]) (x 1))) '(foo 1))
+(check-equal? (expression (weird-let ([x 'foo]) (x 1 2 3))) '(foo 3))
+
+(check-equal? (expression (immutable-let ([x (lambda (y) y)]) (x 2))) 2)
+(check-equal? (expression (mutable-let ([x (lambda (y) y)]) (x 2))) 2)

--- a/tests/reference-compiler-with-application.rkt
+++ b/tests/reference-compiler-with-application.rkt
@@ -20,13 +20,13 @@
  (binding-class number-var)
  (nonterminal expr
               (mutable-let ([x:mutable-var e:racket-expr]) body:racket-expr)
-              #:binding {(bind x) body}
+              #:binding (scope (bind x) body)
               (immutable-let ([x:immutable-var e:racket-expr]) body:racket-expr)
-              #:binding {(bind x) body}
+              #:binding (scope (bind x) body)
               (weird-let ([x:weird-var e:racket-expr]) body:racket-expr)
-              #:binding {(bind x) body}
+              #:binding (scope (bind x) body)
               (number-let ([x:number-var n:number]) body:racket-expr)
-              #:binding {(bind x) body})
+              #:binding (scope (bind x) body))
 
  (host-interface/expression
   (expression e:expr)


### PR DESCRIPTION
we now need to document that users should use `make-variable-like-reference-compiler` instead of `make-variable-like-transformer`

however, before I changed `mutable-reference-compiler` to use `make-variable-like-reference-compiler`, I wrote the tests in `reference-compiler-with-application.rkt` and they worked. But `class.rkt` requires `make-variable-like-reference-compiler` in order to avoid that unbound variable error. What's going on here? When is that error being thrown and what exactly is causing it? Is it during symbol table lookup? Or is it because of the #%expression wrapper?