### PR TITLE
ellipses

### DIFF
--- a/demos/minimal-state-machine/state-machine.rkt
+++ b/demos/minimal-state-machine/state-machine.rkt
@@ -10,7 +10,7 @@
 
   (host-interface/expression
     (machine #:initial-state s:state-name d:machine-decl ...)
-    #:binding (scope (import d) s)
+    #:binding (scope (import d ...) s)
     #'(compile-machine s d ...))
   
   (nonterminal/exporting machine-decl
@@ -23,7 +23,7 @@
     (on (evt:id arg:event-var ...)
       e:racket-expr ...
       ((~datum ->) s:state-name))
-    #:binding (scope (bind arg) e)))
+    #:binding (scope (bind arg) ... e ...)))
 
 (require syntax/parse/define (for-syntax syntax/parse racket/list))
 

--- a/demos/minimal-state-machine/state-machine.rkt
+++ b/demos/minimal-state-machine/state-machine.rkt
@@ -10,7 +10,7 @@
 
   (host-interface/expression
     (machine #:initial-state s:state-name d:machine-decl ...)
-    #:binding (scope (import d ...) s)
+    #:binding (scope (import d) ... s)
     #'(compile-machine s d ...))
   
   (nonterminal/exporting machine-decl

--- a/demos/visser-symposium/state-machine.rkt
+++ b/demos/visser-symposium/state-machine.rkt
@@ -9,7 +9,7 @@
 
   (host-interface/expression
     (machine #:initial-state s:state-name d:machine-decl ...)
-    #:binding (scope (import d) s)
+    #:binding (scope (import d ...) s)
     #'(compile-machine s d ...))
   
   (nonterminal/exporting machine-decl
@@ -23,4 +23,4 @@
     (on (evt:id arg:racket-var ...)
       e:racket-expr ...
       ((~datum ->) s:state-name))
-    #:binding (scope (bind arg) e)))
+    #:binding (scope (bind arg) ... e ...)))

--- a/demos/visser-symposium/state-machine.rkt
+++ b/demos/visser-symposium/state-machine.rkt
@@ -9,7 +9,7 @@
 
   (host-interface/expression
     (machine #:initial-state s:state-name d:machine-decl ...)
-    #:binding (scope (import d ...) s)
+    #:binding (scope (import d) ... s)
     #'(compile-machine s d ...))
   
   (nonterminal/exporting machine-decl

--- a/design/statecharts-full.rkt
+++ b/design/statecharts-full.rkt
@@ -19,7 +19,7 @@
 
     (state n:state-name
       sb:state-body ...)
-    #:binding [(export n) (scope (import sb))]
+    #:binding [(export n) (scope (import sb) ...)]
 
     (use scn:statechart-name #:as sn:state-name
          e:event ...))
@@ -27,7 +27,7 @@
   (nonterminal event
     (on (evt:id arg:var ...)
       ab:action ...+)
-    #:binding (scope (bind arg) ab)
+    #:binding (scope (bind arg) ... ab ...)
 
     (on-enter ab:action ...)
     (on-exit ab:action ...))
@@ -40,7 +40,7 @@
     (emit (name:id arg:racket-expr ...))
 
     (let* (b:binding-group ...) body:action ...)
-    #:binding (nest b body))
+    #:binding (nest b ... [body ...]))
 
   (nonterminal/nesting binding-group (tail)
     [v:var e:racket-expr]

--- a/design/statecharts-smaller.rkt
+++ b/design/statecharts-smaller.rkt
@@ -16,7 +16,7 @@
 
     (state n:state-name
            sb:state-body ...)
-    #:binding [(export n) (scope (import sb))]
+    #:binding [(export n) (scope (import sb) ...)]
 
     (use scn:statechart-name #:as sn:state-name
          e:event ...))
@@ -24,7 +24,7 @@
   (nonterminal event
     (on (evt:id arg:var ...)
         ab:action ...+)
-    #:binding (scope (bind arg) ab))
+    #:binding (scope (bind arg) ... ab))
     
   (nonterminal action
     (-> s:state-name)
@@ -34,7 +34,7 @@
     (emit (name:id arg:racket-expr ...))
 
     (let* (b:binding-group ...) body:action ...)
-    #:binding (nest b body))
+    #:binding (nest b ... body))
 
   (nonterminal/nesting binding-group (tail)
     [v:var e:racket-expr]

--- a/main.rkt
+++ b/main.rkt
@@ -5,6 +5,8 @@
          (for-syntax
           number
           id
+          ...
+          ...+
 
           mutable-reference-compiler
           immutable-reference-compiler

--- a/private/runtime/binding-spec.rkt
+++ b/private/runtime/binding-spec.rkt
@@ -61,7 +61,7 @@
 (struct rename-bind [pvar space] #:transparent)
 (struct bind [pvar space bvalc] #:transparent)
 (struct bind-syntax [pvar space bvalc transformer-pvar] #:transparent)
-(struct bind-syntaxes [pvar space bvalc transformer-pvar] #:transparent)
+(struct bind-syntaxes [depth pvar space bvalc transformer-pvar] #:transparent)
 (struct scope [spec] #:transparent)
 (struct group [specs] #:transparent)
 (struct nest [depth pvar nonterm spec] #:transparent)
@@ -231,7 +231,9 @@
        (define scoped-transformer-stx (add-scopes transformer-stx local-scopes))
        (let ([bound-id (bind-and-record-rename! (add-scopes id local-scopes) #`(#,constr-id #,(flip-intro-scope scoped-transformer-stx)) space)])
          (values scoped-transformer-stx bound-id)))]
-    [(bind-syntaxes pv space constr-id transformer-pv)
+    [(bind-syntaxes depth pv space constr-id transformer-pv)
+     (unless (= 1 depth)
+       (error "don't know how to handle depth > 1 yet"))
      (for/pv-state-tree ([transformer-stx transformer-pv] [ids pv])
        (when DEBUG-RENAME
          (displayln 'bind-syntaxes)

--- a/private/runtime/binding-spec.rkt
+++ b/private/runtime/binding-spec.rkt
@@ -64,7 +64,7 @@
 (struct bind-syntaxes [depth pvar space bvalc transformer-pvar] #:transparent)
 (struct scope [spec] #:transparent)
 (struct group [specs] #:transparent)
-(struct nest [depth pvar nonterm spec] #:transparent)
+(struct nest [pvar nonterm spec] #:transparent)
 (struct nest-one [pvar nonterm spec] #:transparent)
 (struct nested [] #:transparent)
 (struct suspend [pvar] #:transparent)
@@ -280,22 +280,15 @@
                ([spec specs])
        (simple-expand-internal spec st local-scopes))]
     
-    [(nest depth pv f inner-spec)
-     (when (> depth 1)
-       (error "don't know how to handle depth > 1 yet"))
-
-     (define init-seq (if (= 0 depth)
-                          (list (get-pvar st pv))
-                          (get-pvar st pv)))
+    [(nest pv f inner-spec)
+     (define init-seq (get-pvar st pv))
 
      (define res
        (start-nest f init-seq st inner-spec local-scopes))
      
      (match-define (nest-ret done-seq st^) res)
      
-     (set-pvar st^ pv (if (= 0 depth)
-                          (car done-seq)
-                          done-seq))]
+     (set-pvar st^ pv done-seq)]
 
     ; TODO deprecate
     [(nest-one pv f inner-spec)

--- a/private/runtime/binding-spec.rkt
+++ b/private/runtime/binding-spec.rkt
@@ -389,14 +389,14 @@
     (or (for/first ([(_ vs) (in-hash env)])
           (unless (list? vs)
             ; TODO check in compiler
-            (error "too many ellipses in template"))
+            (error "too many ellipses in binding spec"))
           (length vs))
         0))
   (for ([(_ vs) (in-hash env)])
     (unless (= (length vs) result)
       ; TODO Can this be checked in the compiler? Would need to make sure ellipsized bs vars
       ; come from the same ss ellipsis.
-      (error "incompatible ellipsis match counts for template")))
+      (error "incompatible ellipsis match counts for binding spec")))
   result)
 
 (module+ test

--- a/private/runtime/binding-spec.rkt
+++ b/private/runtime/binding-spec.rkt
@@ -75,8 +75,10 @@
 ;; Expansion
 ;;
 
+; A NestState is one of
+;; #f, nest-call, or nest-ret
+
 ;; pvar-vals is (hashof symbol? (treeof syntax?))
-;; nest-state is #f, nest-call, or nest-ret
 (struct exp-state [pvar-vals nest-state])
 
 ;; Helpers for accessing and updating parts of the exp-state
@@ -85,7 +87,7 @@
 (define (get-pvar st pv)
   (hash-ref (exp-state-pvar-vals st) pv))
 
-; exp-state? symbol? (treeof syntax?) -> (treeof syntax?)
+; exp-state? symbol? (treeof syntax?) -> exp-state?
 (define (set-pvar st pv val)
   (struct-copy
    exp-state st
@@ -107,7 +109,7 @@
    exp-state st
    [pvar-vals env^]))
 
-; exp-state? ((or/c #f nest-call? nest-ret?) -> (or/c #f nest-call? nest-ret?)) -> exp-state?
+; exp-state? (NestState -> NestState) -> exp-state?
 (define (update-nest-state st f)
   (struct-copy
    exp-state st

--- a/private/runtime/binding-spec.rkt
+++ b/private/runtime/binding-spec.rkt
@@ -281,18 +281,23 @@
        (simple-expand-internal spec st local-scopes))]
     
     [(nest depth pv f inner-spec)
-     (unless (= 1 depth)
+     (unless (< 1 depth)
        (error "don't know how to handle depth > 1 yet"))
 
-     (define init-seq (get-pvar st pv))
+     (define init-seq (if (= 0 depth)
+                          (list (get-pvar st pv))
+                          (get-pvar st pv)))
 
      (define res
        (start-nest f init-seq st inner-spec local-scopes))
      
      (match-define (nest-ret done-seq st^) res)
      
-     (set-pvar st^ pv done-seq)]
+     (set-pvar st^ pv (if (= 0 depth)
+                          (car done-seq)
+                          done-seq))]
 
+    ; TODO deprecate
     [(nest-one pv f inner-spec)
      (define init-seq (list (get-pvar st pv)))
 

--- a/private/runtime/binding-spec.rkt
+++ b/private/runtime/binding-spec.rkt
@@ -281,7 +281,7 @@
        (simple-expand-internal spec st local-scopes))]
     
     [(nest depth pv f inner-spec)
-     (unless (< 1 depth)
+     (when (> depth 1)
        (error "don't know how to handle depth > 1 yet"))
 
      (define init-seq (if (= 0 depth)

--- a/private/runtime/binding-spec.rkt
+++ b/private/runtime/binding-spec.rkt
@@ -320,7 +320,7 @@
      ; unsplit the sub-environments and merge that into the initial env.
      (for/fold ([st st])
                ([pv pvs])
-       (set-pvar st pv (for/list ([st^ sts^]) (hash-ref st^ pv))))]))
+       (set-pvar st pv (for/list ([st^ sts^]) (hash-ref (exp-state-pvar-vals st^) pv))))]))
 
 ; f is nonterm-transformer
 ; seq is (listof (treeof syntax?))
@@ -350,8 +350,8 @@
 (define (exp-state-split/ellipsis st pvars)
   (match st
     [(exp-state pvar-vals nest-state)
-     (exp-state (env-split/ellipsis pvar-vals pvars)
-                nest-state)]))
+     (for/list ([env (env-split/ellipsis pvar-vals pvars)])
+       (exp-state env nest-state))]))
 
 ; (hash symbol? (treeof syntax?)) (listof symbol?) -> (listof (hash symbol? (treeof syntax?)))
 ; Spit up the environment into a list of envs. One per element of a pvar's value.

--- a/private/runtime/binding-spec.rkt
+++ b/private/runtime/binding-spec.rkt
@@ -61,7 +61,7 @@
 (struct rename-bind [pvar space] #:transparent)
 (struct bind [pvar space bvalc] #:transparent)
 (struct bind-syntax [pvar space bvalc transformer-pvar] #:transparent)
-(struct bind-syntaxes [depth pvar space bvalc transformer-pvar] #:transparent)
+(struct bind-syntaxes [pvar space bvalc transformer-pvar] #:transparent)
 (struct scope [spec] #:transparent)
 (struct group [specs] #:transparent)
 (struct nest [pvar nonterm spec] #:transparent)
@@ -233,9 +233,7 @@
        (define scoped-transformer-stx (add-scopes transformer-stx local-scopes))
        (let ([bound-id (bind-and-record-rename! (add-scopes id local-scopes) #`(#,constr-id #,(flip-intro-scope scoped-transformer-stx)) space)])
          (values scoped-transformer-stx bound-id)))]
-    [(bind-syntaxes depth pv space constr-id transformer-pv)
-     (unless (= 1 depth)
-       (error "don't know how to handle depth > 1 yet"))
+    [(bind-syntaxes pv space constr-id transformer-pv)
      (for/pv-state-tree ([transformer-stx transformer-pv] [ids pv])
        (when DEBUG-RENAME
          (displayln 'bind-syntaxes)

--- a/private/syntax/compile/binding-spec.rkt
+++ b/private/syntax/compile/binding-spec.rkt
@@ -53,12 +53,12 @@
 (struct ref [pvar] #:transparent)
 (struct bind with-stx [pvar] #:transparent)
 (struct bind-syntax with-stx [pvar transformer-pvar] #:transparent)
-(struct bind-syntaxes with-stx [pvar transformer-pvar] #:transparent)
-(struct rec with-stx [pvar] #:transparent)
+(struct bind-syntaxes with-stx [depth pvar transformer-pvar] #:transparent)
+(struct rec with-stx [depth pvar] #:transparent)
 (struct re-export with-stx [pvar] #:transparent)
 (struct export with-stx [pvar] #:transparent)
 (struct export-syntax with-stx [pvar transformer-pvar] #:transparent)
-(struct export-syntaxes with-stx [pvar transformer-pvar] #:transparent)
+(struct export-syntaxes with-stx [depth pvar transformer-pvar] #:transparent)
 (struct nest with-stx [depth pvar spec] #:transparent)
 (struct nest-one with-stx [pvar spec] #:transparent) 
 (struct suspend with-stx [pvar] #:transparent)
@@ -132,17 +132,22 @@
                       (? stxclass-rep?)
                       "syntax class"))]
     [(bind-syntaxes ~! v:nonref-id v-transformer:nonref-id)
+     #;(bind-syntaxes ~! v:nonref-id (~and ooo (~literal ...)) ... v-transformer:nonref-id)
+     ; TODO update syntax
      (bind-syntaxes
       this-syntax
+      1
+      #;(length (attribute ooo))
       (elaborate-pvar (attribute v)
                       (s* extclass-rep)
                       "extension class")
       (elaborate-pvar (attribute v-transformer)
                       (? stxclass-rep?)
                       "syntax class"))]
-    [(import ~! v:nonref-id)
+    [(import ~! v:nonref-id (~and ooo (~literal ...)) ...)
      (rec
          this-syntax
+         (length (attribute ooo))
          (elaborate-pvar (attribute v)
                          (s* nonterm-rep [variant-info (s* exporting-nonterm-info)])
                          "exporting nonterminal"))]
@@ -168,8 +173,12 @@
                       (? stxclass-rep?)
                       "syntax class"))]
     [(export-syntaxes ~! v:nonref-id v-transformer:nonref-id)
+     #;(export-syntaxes ~! v:nonref-id (~and ooo (~literal ...)) ... v-transformer:nonref-id)
+     ; TODO update syntax
      (export-syntaxes
       this-syntax
+      1
+      #;(length (attribute ooo))
       (elaborate-pvar (attribute v)
                       (s* extclass-rep)
                       "extension class")
@@ -507,9 +516,9 @@
      #`(group (list (bind '#,v '#,space #'#,constr) (rename-bind '#,v '#,space)))]
     [(bind-syntax _ (pvar v (extclass-rep constr _ _ space)) (pvar v-transformer _))
      #`(group (list (bind-syntax '#,v '#,space #'#,constr '#,v-transformer) (rename-bind '#,v '#,space)))]
-    [(bind-syntaxes _ (pvar v (extclass-rep constr _ _ space)) (pvar v-transformer _))
-     #`(group (list (bind-syntaxes '#,v '#,space #'#,constr '#,v-transformer) (rename-bind '#,v '#,space)))]
-    [(rec _ pv)
+    [(bind-syntaxes _ depth (pvar v (extclass-rep constr _ _ space)) (pvar v-transformer _))
+     #`(group (list (bind-syntaxes #,depth '#,v '#,space #'#,constr '#,v-transformer) (rename-bind '#,v '#,space)))]
+    [(rec _ _ pv)
      (with-syntax ([s-cp1 (match pv
                             [(pvar v (nonterm-rep (exporting-nonterm-info pass1-expander _)))
                              #`(subexp '#,v #,pass1-expander)])]
@@ -564,8 +573,8 @@
      #`(group (list (bind '#,v '#,space #'#,constr) (rename-bind '#,v '#,space)))]
     [(export-syntax _ (pvar v (extclass-rep constr _ _ space)) (pvar v-transformer _))
      #`(group (list (bind-syntax '#,v '#,space #'#,constr '#,v-transformer) (rename-bind '#,v '#,space)))]
-    [(export-syntaxes _ (pvar v (extclass-rep constr _ _ space)) (pvar v-transformer _))
-     #`(group (list (bind-syntaxes '#,v '#,space #'#,constr '#,v-transformer) (rename-bind '#,v '#,space)))]
+    [(export-syntaxes _ depth (pvar v (extclass-rep constr _ _ space)) (pvar v-transformer _))
+     #`(group (list (bind-syntaxes #,depth '#,v '#,space #'#,constr '#,v-transformer) (rename-bind '#,v '#,space)))]
     [(re-export _ pv)
      (match-define (pvar v (nonterm-rep (exporting-nonterm-info pass1-expander _))) pv)
      #`(subexp '#,v #,pass1-expander)]

--- a/private/syntax/compile/binding-spec.rkt
+++ b/private/syntax/compile/binding-spec.rkt
@@ -214,8 +214,8 @@
      ; however many ellipses follow the pattern, wrap the elaborated spec with
      ; the ellipses struct that many times.
      (cons (for/fold ([spec (elaborate-bspec (attribute spec))])
-                     ([_ (attribute ooo)])
-             (ellipsis spec))
+                     ([ooo (attribute ooo)])
+             (ellipsis ooo spec))
            (elaborate-group (attribute specs)))]
     [() '()]))
 
@@ -541,7 +541,7 @@
     [(ellipsis _ spec)
      (define vs (bspec-referenced-pvars spec))
      (with-syntax ([spec-c (compile-bspec-term/single-pass spec)])
-       #`(ellipsis #,vs spec-c))]))
+       #`(ellipsis '#,vs spec-c))]))
 
 (define no-op #'(group (list)))
 
@@ -572,7 +572,7 @@
     [(ellipsis _ spec)
      (define vs (bspec-referenced-pvars spec))
      (with-syntax ([spec-c (compile-bspec-term/pass1 spec)])
-       #`(ellipsis #,vs spec-c))]))
+       #`(ellipsis '#,vs spec-c))]))
 
 (define (compile-bspec-term/pass2 spec)
   (match spec
@@ -598,4 +598,4 @@
     [(ellipsis _ spec)
      (define vs (bspec-referenced-pvars spec))
      (with-syntax ([spec-c (compile-bspec-term/pass2 spec)])
-       #`(ellipsis #,vs spec-c))]))
+       #`(ellipsis '#,vs spec-c))]))

--- a/private/syntax/compile/binding-spec.rkt
+++ b/private/syntax/compile/binding-spec.rkt
@@ -33,8 +33,7 @@
   (check-ellipsis-depth! bspec-elaborated)
   (check-ellipsis-homogeneity! bspec-elaborated)
   (define bspec-with-implicits (add-implicit-pvar-refs bspec-elaborated bound-pvars))
-  (define bspec-flattened (bspec-flatten-groups bspec-with-implicits))
-  (define bspec-combined-imports (bspec-combine-imports bspec-flattened))
+  (define bspec-combined-imports (bspec-combine-imports bspec-with-implicits))
 
   (syntax-parse variant
     [(~or #:simple (#:nesting _))
@@ -428,16 +427,6 @@
      (append* node-vars children))
    spec))
 
-;; Flatten groups for easier order analysis
-
-(define (bspec-flatten-groups bspec)
-  (map-bspec
-   (lambda (spec)
-     (match spec
-       [(group l) (group (append* (map flat-bspec-top-elements l)))]
-       [_ spec]))
-   bspec))
-
 (define (flat-bspec-top-elements el)
   (match el
     [(group l) l]
@@ -551,7 +540,6 @@
       [(s* ellipsis [spec s])
        (bindings s specs)]
       [(group (cons group-spec group-specs))
-       ; inline flatten
        (bindings group-spec (append group-specs specs))]
       [(group (list)) (check-sequence bindings specs)]
       [(or (s* bind) (s* bind-syntax) (s* bind-syntaxes))
@@ -604,7 +592,6 @@
       [(s* ellipsis [spec s])
        (exports s specs)]
       [(group (cons group-spec group-specs))
-       ; inline flatten
        (exports group-spec (append group-specs specs))]
       [(group (list)) (check-sequence exports specs)]
       [(or (s* export) (s* export-syntax) (s* export-syntaxes))
@@ -616,7 +603,6 @@
       [(s* ellipsis [spec s])
        (re-exports s specs)]
       [(group (cons group-spec group-specs))
-       ; inline flatten
        (re-exports group-spec (append group-specs specs))]
       [(group (list)) (check-sequence re-exports specs)]
       [(s* re-export)
@@ -629,7 +615,6 @@
       [(s* ellipsis [spec s])
        (refs+subexps s specs)]
       [(group (cons group-spec group-specs))
-       ; inline flatten
        (refs+subexps group-spec (append group-specs specs))]
       [(group (list)) (check-sequence refs+subexps specs)]
       [(and (or (s* bind) (s* bind-syntax) (s* bind-syntaxes)) (with-stx stx))

--- a/private/syntax/compile/binding-spec.rkt
+++ b/private/syntax/compile/binding-spec.rkt
@@ -139,13 +139,10 @@
       (elaborate-pvar (attribute v-transformer)
                       (? stxclass-rep?)
                       "syntax class"))]
-    [(bind-syntaxes ~! v:nonref-id v-transformer:nonref-id)
-     #;(bind-syntaxes ~! v:nonref-id (~and ooo (~literal ...)) ... v-transformer:nonref-id)
-     ; TODO update syntax
+    [(bind-syntaxes ~! v:nonref-id (~and ooo (~literal ...)) ... v-transformer:nonref-id)
      (bind-syntaxes
       this-syntax
-      1
-      #;(length (attribute ooo))
+      (length (attribute ooo))
       (elaborate-pvar (attribute v)
                       (s* extclass-rep)
                       "extension class")
@@ -157,11 +154,11 @@
      (when (> depth 1)
        (wrong-syntax/orig this-syntax "import cannot contain more than one ellipsis"))
      (rec
-         this-syntax
-         (length (attribute ooo))
-         (elaborate-pvar (attribute v)
-                         (s* nonterm-rep [variant-info (s* exporting-nonterm-info)])
-                         "exporting nonterminal"))]
+      this-syntax
+      (length (attribute ooo))
+      (elaborate-pvar (attribute v)
+                      (s* nonterm-rep [variant-info (s* exporting-nonterm-info)])
+                      "exporting nonterminal"))]
     [(re-export ~! v:nonref-id)
      (re-export
       this-syntax
@@ -183,30 +180,24 @@
       (elaborate-pvar (attribute v-transformer)
                       (? stxclass-rep?)
                       "syntax class"))]
-    [(export-syntaxes ~! v:nonref-id v-transformer:nonref-id)
-     #;(export-syntaxes ~! v:nonref-id (~and ooo (~literal ...)) ... v-transformer:nonref-id)
-     ; TODO update syntax
+    [(export-syntaxes ~! v:nonref-id (~and ooo (~literal ...)) ... v-transformer:nonref-id)
      (export-syntaxes
       this-syntax
-      1
-      #;(length (attribute ooo))
+      (length (attribute ooo))
       (elaborate-pvar (attribute v)
                       (s* extclass-rep)
                       "extension class")
       (elaborate-pvar (attribute v-transformer)
                       (? stxclass-rep?)
                       "syntax class"))]
-    [#;(nest-one ~! v:nonref-id spec:bspec-term)
-     (nest v:nonref-id spec:bspec-term)
-     ; TODO update syntax after old examples work
+    [(nest v:nonref-id spec:bspec-term)
      (nest-one
       this-syntax
       (elaborate-pvar (attribute v)
                       (s* nonterm-rep [variant-info (s* nesting-nonterm-info)])
                       "nesting nonterminal")
       (elaborate-bspec (attribute spec)))]
-    [#;(nest ~! v:nonref-id spec:bspec-term)
-     (nest ~! v:nonref-id (~and (~literal ...) ooo) ...+ spec:bspec-term)
+    [(nest ~! v:nonref-id (~and (~literal ...) ooo) ...+ spec:bspec-term)
      (nest
       this-syntax
       (length (attribute ooo))

--- a/private/syntax/compile/binding-spec.rkt
+++ b/private/syntax/compile/binding-spec.rkt
@@ -598,7 +598,7 @@
     [(bind-syntax _ (pvar v (extclass-rep constr _ _ space)) (pvar v-transformer _))
      #`(group (list (bind-syntax '#,v '#,space #'#,constr '#,v-transformer) (rename-bind '#,v '#,space)))]
     [(bind-syntaxes _ depth (pvar v (extclass-rep constr _ _ space)) (pvar v-transformer _))
-     #`(group (list (bind-syntaxes #,depth '#,v '#,space #'#,constr '#,v-transformer) (rename-bind '#,v '#,space)))]
+     #`(group (list (bind-syntaxes '#,v '#,space #'#,constr '#,v-transformer) (rename-bind '#,v '#,space)))]
     [(recs ss)
      (match ss
        [(list (rec _ _ pvs) ...)
@@ -664,7 +664,7 @@
     [(export-syntax _ (pvar v (extclass-rep constr _ _ space)) (pvar v-transformer _))
      #`(group (list (bind-syntax '#,v '#,space #'#,constr '#,v-transformer) (rename-bind '#,v '#,space)))]
     [(export-syntaxes _ depth (pvar v (extclass-rep constr _ _ space)) (pvar v-transformer _))
-     #`(group (list (bind-syntaxes #,depth '#,v '#,space #'#,constr '#,v-transformer) (rename-bind '#,v '#,space)))]
+     #`(group (list (bind-syntaxes '#,v '#,space #'#,constr '#,v-transformer) (rename-bind '#,v '#,space)))]
     [(re-export _ pv)
      (match-define (pvar v (nonterm-rep (exporting-nonterm-info pass1-expander _))) pv)
      #`(subexp '#,v #,pass1-expander)]

--- a/private/syntax/compile/binding-spec.rkt
+++ b/private/syntax/compile/binding-spec.rkt
@@ -198,9 +198,12 @@
                       "nesting nonterminal")
       (elaborate-bspec (attribute spec)))]
     [(nest ~! v:nonref-id (~and (~literal ...) ooo) ...+ spec:bspec-term)
+     (define depth (length (attribute ooo)))
+     (when (> depth 1)
+       (wrong-syntax/orig this-syntax "nest cannot contain more than one ellipsis"))
      (nest
       this-syntax
-      (length (attribute ooo))
+      depth
       (elaborate-pvar (attribute v)
                       (s* nonterm-rep [variant-info (s* nesting-nonterm-info)])
                       "nesting nonterminal")

--- a/private/syntax/compile/binding-spec.rkt
+++ b/private/syntax/compile/binding-spec.rkt
@@ -550,6 +550,10 @@
     (match spec
       [(s* ellipsis [spec s])
        (bindings s specs)]
+      [(group (cons group-spec group-specs))
+       ; inline flatten
+       (bindings group-spec (append group-specs specs))]
+      [(group (list)) (check-sequence bindings specs)]
       [(or (s* bind) (s* bind-syntax) (s* bind-syntaxes))
        (check-sequence bindings specs)]
       [(and (or (s* export) (s* export-syntax) (s* export-syntaxes)) (with-stx stx))
@@ -566,6 +570,10 @@
     (match spec
       [(s* ellipsis [spec s])
        (refs+subexps s specs)]
+      [(group (cons group-spec group-specs))
+       ; inline flatten
+       (refs+subexps group-spec (append group-specs specs))]
+      [(group (list)) (check-sequence refs+subexps specs)]
       [(and (or (s* bind) (s* bind-syntax) (s* bind-syntaxes)) (with-stx stx))
        (wrong-syntax/orig stx "bindings must appear first within a scope")]
       [(and (or (s* export) (s* export-syntax) (s* export-syntaxes)) (with-stx stx))
@@ -595,6 +603,10 @@
     (match spec
       [(s* ellipsis [spec s])
        (exports s specs)]
+      [(group (cons group-spec group-specs))
+       ; inline flatten
+       (exports group-spec (append group-specs specs))]
+      [(group (list)) (check-sequence exports specs)]
       [(or (s* export) (s* export-syntax) (s* export-syntaxes))
        (check-sequence exports specs)]
       [_ (check-sequence re-exports (cons spec specs))]))
@@ -603,6 +615,10 @@
     (match spec
       [(s* ellipsis [spec s])
        (re-exports s specs)]
+      [(group (cons group-spec group-specs))
+       ; inline flatten
+       (re-exports group-spec (append group-specs specs))]
+      [(group (list)) (check-sequence re-exports specs)]
       [(s* re-export)
        (check-sequence re-exports specs)]
       [_
@@ -612,6 +628,10 @@
     (match spec
       [(s* ellipsis [spec s])
        (refs+subexps s specs)]
+      [(group (cons group-spec group-specs))
+       ; inline flatten
+       (refs+subexps group-spec (append group-specs specs))]
+      [(group (list)) (check-sequence refs+subexps specs)]
       [(and (or (s* bind) (s* bind-syntax) (s* bind-syntaxes)) (with-stx stx))
        (binding-scope-error stx)]
       [(and (or (s* export) (s* export-syntax) (s* export-syntaxes)) (with-stx stx))

--- a/private/syntax/compile/binding-spec.rkt
+++ b/private/syntax/compile/binding-spec.rkt
@@ -625,7 +625,7 @@
      (match info
        [(nonterm-rep (nesting-nonterm-info expander))
         (with-syntax ([spec-c (compile-bspec-term/single-pass spec)])
-          #`(nest #,depth '#,v #,expander spec-c))])]
+          #`(nest '#,v #,expander spec-c))])]
     [(nest-one _ (pvar v info) spec)
      (match info
        [(nonterm-rep (nesting-nonterm-info expander))

--- a/private/syntax/compile/binding-spec.rkt
+++ b/private/syntax/compile/binding-spec.rkt
@@ -145,6 +145,9 @@
                       (? stxclass-rep?)
                       "syntax class"))]
     [(import ~! v:nonref-id (~and ooo (~literal ...)) ...)
+     (define depth (length (attribute ooo)))
+     (when (> depth 1)
+       (wrong-syntax/orig this-syntax "import cannot contain more than one ellipsis"))
      (rec
          this-syntax
          (length (attribute ooo))

--- a/private/syntax/compile/nonterminal-expander.rkt
+++ b/private/syntax/compile/nonterminal-expander.rkt
@@ -49,7 +49,7 @@
        (syntax-parse (attribute variant)
          [(#:nesting nested-id:id)
           (with-scope sc
-            (define id^ (bind! (add-scope (attribute nested-id) sc) (pvar-rep (nested-binding))))
+            (define id^ (bind! (add-scope (attribute nested-id) sc) (pvar-rep (nested-binding) 0)))
             #`(wrap-hygiene
                (lambda (stx-a)
                  #,(generate-loop (add-scope #'(prod-arg ...) sc) id^ #'stx-a))

--- a/private/syntax/compile/syntax-spec.rkt
+++ b/private/syntax/compile/syntax-spec.rkt
@@ -134,17 +134,17 @@
   (define res '())
 
   ;; records left-to-right
-  (let rec ([stx stx])
+  (let rec ([stx stx] [depth 0])
     (syntax-parse stx
       #:context 'extract-var-mapping
-      [(a . d)
-       (rec #'a)
-       (rec #'d)]
+      [(a (~and ooo (~or (~literal ...) (~literal ...+))) ... . d)
+       (rec #'a (+ depth (length (attribute ooo))))
+       (rec #'d depth)]
       [r:ref-id
        #:with c:special-syntax-class #'r.ref
        (when (member #'r.var res bound-identifier=?)
          (wrong-syntax/orig #'r.ref "duplicate pattern variable"))
-       (bind! #'r.var (pvar-rep (special-syntax-class-binding)))
+       (bind! #'r.var (pvar-rep (special-syntax-class-binding) depth))
        (set! res (cons #'r.var res))]
       [r:ref-id
        (define binding (lookup #'r.ref
@@ -157,7 +157,7 @@
          (wrong-syntax/orig #'r.ref "expected a reference to a binding class, extension class, syntax class, or nonterminal"))
        (when (member #'r.var res bound-identifier=?)
          (wrong-syntax/orig #'r.ref "duplicate pattern variable"))
-       (bind! #'r.var (pvar-rep binding))
+       (bind! #'r.var (pvar-rep binding depth))
        (set! res (cons #'r.var res))]
       [_ (void)]))
   

--- a/private/syntax/env-reps.rkt
+++ b/private/syntax/env-reps.rkt
@@ -74,7 +74,7 @@
 ;   bindclass-rep
 ;   nonterm-rep
 ;   nested-binding
-(struct pvar-rep (var-info))
+(struct pvar-rep (var-info depth))
 
 (struct nested-binding [])
 (struct special-syntax-class-binding [])

--- a/private/test/sequence.rkt
+++ b/private/test/sequence.rkt
@@ -49,7 +49,7 @@
       [(mylang-let* (b ...) e)
        ; #:binding (fold b e)
        (define bspec
-         (nest 'b mylang-expand-binding-group
+         (nest 1 'b mylang-expand-binding-group
                (subexp 'e mylang-expand-expr)))
 
        (expand-function-return

--- a/private/test/sequence.rkt
+++ b/private/test/sequence.rkt
@@ -49,7 +49,7 @@
       [(mylang-let* (b ...) e)
        ; #:binding (fold b e)
        (define bspec
-         (nest 1 'b mylang-expand-binding-group
+         (nest 'b mylang-expand-binding-group
                (subexp 'e mylang-expand-expr)))
 
        (expand-function-return

--- a/scribblings/reference/specifying.scrbl
+++ b/scribblings/reference/specifying.scrbl
@@ -420,6 +420,44 @@ Similar to syntax patterns and templates, syntax specs and binding specs have a 
 }
 ]
 
+There are several other constraints on binding specs:
+
+@itemlist[
+@item{
+  Specs of different categories cannot occur within the same ellipsis. The categories of specs are:
+  @itemlist[
+    @item{
+      @racket[refs+subexps] include references, @racket[nest], and @racket[scope].
+    }
+    @item{
+      @racket[binds] include @racket[bind], @racket[bind-syntax], and @racket[bind-syntaxes].
+    }
+    @item{
+      @racket[imports] include @racket[import].
+    }
+    @item{
+      @racket[exports] include @racket[export], @racket[export-syntax], @racket[export-syntaxes], and @racket[re-export].
+    }
+  ]
+  For example, the spec @racket[(scope [(bind x) e] ...)] is illegal since it mixes @racket[refs+subexps] and @racket[binds] in an ellipsis.
+}
+@item{
+  @racket[binds] and @racket[imports] can only occur within a @racket[scope]
+}
+@item{
+  @racket[exports] cannot occur within a scope.
+}
+@item{
+  Within a scope, there can be zero or more @racket[binds], followed by zero or more @racket[imports], followed by zero or more @racket[refs+subexps].
+}
+@item{
+  The second argument to nest must be @racket[refs+subexps].
+}
+@item{
+  Spec variables can be used at most once. For example, @racket[(scope (bind x) e e)] is illegal.
+}
+]
+
 @section{Host interface forms}
 
 Host interface forms are the entry point to the DSL from the host language. They often invoke a compiler macro to translate

--- a/scribblings/tutorial/stlc-tutorial.scrbl
+++ b/scribblings/tutorial/stlc-tutorial.scrbl
@@ -28,11 +28,11 @@ Let's start out with defining the grammar and binding rules for basic typed expr
     n:number
 
     (#%lambda ([x:typed-var (~datum :) t:type] ...) body:typed-expr)
-    #:binding (scope (bind x) body)
+    #:binding (scope (bind x) ... body)
     (#%app fun:typed-expr arg:typed-expr ...)
 
     (#%let ([x:typed-var e:typed-expr] ...) body:typed-expr)
-    #:binding (scope (bind x) body)
+    #:binding (scope (bind x) ... body)
 
     (~> (e (~datum :) t)
         #'(: e t))
@@ -362,7 +362,7 @@ Next, let's add definitions to our language:
     ...
 
     (block d:typed-definition-or-expr ... e:typed-expr)
-    #:binding (scope (import d) e)
+    #:binding (scope (import d) ... e)
 
     ...)
 
@@ -374,14 +374,14 @@ Next, let's add definitions to our language:
     (#%define x:typed-var t:type e:typed-expr)
     #:binding (export x)
     (begin defn:typed-definition-or-expr ...+)
-    #:binding (re-export defn)
+    #:binding [(re-export defn) ...]
     e:typed-expr)
 
   ...
 
   (host-interface/definitions
    (stlc body:typed-definition-or-expr ...+)
-   #:binding (re-export body)
+   #:binding [(re-export body) ...]
    (type-check-defn-or-expr/pass1 #'(begin body ...))
    (type-check-defn-or-expr/pass2 #'(begin body ...))
    #'(compile-defn-or-expr/top (begin body ...))))

--- a/testing.rkt
+++ b/testing.rkt
@@ -35,9 +35,10 @@
   (check-exn
    (check-formatted-error-matches rx)
    (lambda ()
-     (eval-syntax #`(module m racket/base
-                      (require "../main.rkt")
-                      decl-stx)))))
+     (eval-syntax (quote-syntax
+                   (module m racket/base
+                     (require "../main.rkt")
+                     decl-stx))))))
 
 (define-syntax-rule (check-phase1-error rx e)
   (check-exn

--- a/tests/basic-langs/bind-syntax.rkt
+++ b/tests/basic-langs/bind-syntax.rkt
@@ -20,7 +20,7 @@
     #:binding (scope (bind-syntax v e) ... b)
 
     (racket-letrec-syntaxes ([(v:racket-macro ...) e:expr] ...) b:racket-like-expr)
-    #:binding (scope (bind-syntaxes v e) ... b)
+    #:binding (scope (bind-syntaxes v ... e) ... b)
     e:racket-expr)
 
   (host-interface/expression
@@ -56,7 +56,7 @@
     #:binding (scope (bind-syntax v e) ... b)
 
     (my-letrec-syntaxes ([(v:my-macro ...) e:expr] ...) b:my-expr)
-    #:binding (scope (bind-syntaxes v e) ... b)
+    #:binding (scope (bind-syntaxes v ... e) ... b)
 
     ; this binds racket-macros, which cannot be used in my-exprs
     ; uses of bound macros should error.
@@ -64,7 +64,7 @@
     #:binding (scope (bind-syntax v e) ... b)
 
     (bad-my-letrec-syntaxes ([(v:racket-macro ...) e:expr] ...) b:my-expr)
-    #:binding (scope (bind-syntaxes v e) ... b))
+    #:binding (scope (bind-syntaxes v ... e) ... b))
 
   (host-interface/expression
     (my-lang e:my-expr)

--- a/tests/basic-langs/bind-syntax.rkt
+++ b/tests/basic-langs/bind-syntax.rkt
@@ -17,10 +17,10 @@
     n:number
     ((~literal +) e:racket-like-expr ...)
     (racket-letrec-syntax ([v:racket-macro e:expr] ...) b:racket-like-expr)
-    #:binding (scope (bind-syntax v e) b)
+    #:binding (scope (bind-syntax v e) ... b)
 
     (racket-letrec-syntaxes ([(v:racket-macro ...) e:expr] ...) b:racket-like-expr)
-    #:binding (scope (bind-syntaxes v e) b)
+    #:binding (scope (bind-syntaxes v e) ... b)
     e:racket-expr)
 
   (host-interface/expression
@@ -50,21 +50,21 @@
     ((~literal +) e:my-expr ...)
 
     (my-let ([v:my-var e:my-expr] ...) b:my-expr)
-    #:binding (scope (bind v) b)
+    #:binding (scope (bind v) ... b)
 
     (my-letrec-syntax ([v:my-macro e:expr] ...) b:my-expr)
-    #:binding (scope (bind-syntax v e) b)
+    #:binding (scope (bind-syntax v e) ... b)
 
     (my-letrec-syntaxes ([(v:my-macro ...) e:expr] ...) b:my-expr)
-    #:binding (scope (bind-syntaxes v e) b)
+    #:binding (scope (bind-syntaxes v e) ... b)
 
     ; this binds racket-macros, which cannot be used in my-exprs
     ; uses of bound macros should error.
     (bad-my-letrec-syntax ([v:racket-macro e:expr] ...) b:my-expr)
-    #:binding (scope (bind-syntax v e) b)
+    #:binding (scope (bind-syntax v e) ... b)
 
     (bad-my-letrec-syntaxes ([(v:racket-macro ...) e:expr] ...) b:my-expr)
-    #:binding (scope (bind-syntaxes v e) b))
+    #:binding (scope (bind-syntaxes v e) ... b))
 
   (host-interface/expression
     (my-lang e:my-expr)

--- a/tests/basic-langs/block.rkt
+++ b/tests/basic-langs/block.rkt
@@ -22,7 +22,7 @@
 
   (host-interface/expression
     (block body:block-form ...)
-    #:binding (scope (import body ...))
+    #:binding (scope (import body) ...)
     #'(compile-block body ...)))
 
 (define-syntax compile-block

--- a/tests/basic-langs/block.rkt
+++ b/tests/basic-langs/block.rkt
@@ -13,7 +13,7 @@
     #:allow-extension racket-macro
 
     ((~literal define-values) (x:racket-var ...) e:racket-expr)
-    #:binding (export x)
+    #:binding [(export x) ...]
 
     ((~literal define-syntaxes) (x:racket-macro ...) e:expr)
     #:binding (export-syntaxes x e)
@@ -22,7 +22,7 @@
 
   (host-interface/expression
     (block body:block-form ...)
-    #:binding (scope (import body))
+    #:binding (scope (import body) ...)
     #'(compile-block body ...)))
 
 (define-syntax compile-block

--- a/tests/basic-langs/block.rkt
+++ b/tests/basic-langs/block.rkt
@@ -16,7 +16,7 @@
     #:binding [(export x) ...]
 
     ((~literal define-syntaxes) (x:racket-macro ...) e:expr)
-    #:binding (export-syntaxes x e)
+    #:binding (export-syntaxes x ... e)
 
     e:racket-expr)
 

--- a/tests/basic-langs/block.rkt
+++ b/tests/basic-langs/block.rkt
@@ -22,7 +22,7 @@
 
   (host-interface/expression
     (block body:block-form ...)
-    #:binding (scope (import body) ...)
+    #:binding (scope (import body ...))
     #'(compile-block body ...)))
 
 (define-syntax compile-block

--- a/tests/basic-langs/define-star.rkt
+++ b/tests/basic-langs/define-star.rkt
@@ -16,14 +16,14 @@
     (+ e1:expr e2:expr)
     
     (block d:def-or-expr ...)
-    #:binding (nest d []))
+    #:binding (nest d ... []))
 
   (nonterminal/nesting def-or-expr (tail)
     #:description "mylang definition context"
     #:allow-extension mylang-macro
 
     (begin d:def-or-expr ...)
-    #:binding (nest d tail)
+    #:binding (nest d ... tail)
     
     (define*-values (v:var ...) e:expr)
     #:binding [e (scope (bind v) ... tail)]

--- a/tests/basic-langs/define-star.rkt
+++ b/tests/basic-langs/define-star.rkt
@@ -26,7 +26,7 @@
     #:binding (nest d tail)
     
     (define*-values (v:var ...) e:expr)
-    #:binding [e (scope (bind v) tail)]
+    #:binding [e (scope (bind v) ... tail)]
     
     e:expr))
 

--- a/tests/basic-langs/define.rkt
+++ b/tests/basic-langs/define.rkt
@@ -22,7 +22,7 @@
     #:binding (scope (bind v) ... ... rhs ... (scope (import d)))
 
     (dsl-let* (b:binding ...) e:expr)
-    #:binding (nest b e)
+    #:binding (nest b ... e)
 
     (v:var e:expr ...))
 

--- a/tests/basic-langs/define.rkt
+++ b/tests/basic-langs/define.rkt
@@ -16,7 +16,7 @@
     (dsl-+ e1:expr e2:expr)
                
     (dsl-lambda (v:var ...) d:def-or-expr ...)
-    #:binding (scope (bind v) ... (scope (import d ...)))
+    #:binding (scope (bind v) ... (scope (import d) ...))
 
     (dsl-letrec-values ([(v:var ...) rhs:expr] ...) d:def-or-expr)
     #:binding (scope (bind v) ... ... rhs ... (scope (import d)))

--- a/tests/basic-langs/define.rkt
+++ b/tests/basic-langs/define.rkt
@@ -16,10 +16,10 @@
     (dsl-+ e1:expr e2:expr)
                
     (dsl-lambda (v:var ...) d:def-or-expr ...)
-    #:binding (scope (bind v) (scope (import d)))
+    #:binding (scope (bind v) ... (scope (import d ...)))
 
     (dsl-letrec-values ([(v:var ...) rhs:expr] ...) d:def-or-expr)
-    #:binding (scope (bind v) rhs (scope (import d)))
+    #:binding (scope (bind v) ... ... rhs ... (scope (import d)))
 
     (dsl-let* (b:binding ...) e:expr)
     #:binding (nest b e)
@@ -37,10 +37,10 @@
     #:allow-extension dsl-macro
 
     (dsl-begin d:def-or-expr ...)
-    #:binding (re-export d)
+    #:binding [(re-export d) ...]
     
     (dsl-define-values (v:var ...) e:expr)
-    #:binding [(export v) e]
+    #:binding [(export v) ... e]
     
     e:expr))
 
@@ -55,6 +55,15 @@
 (check-equal?
  (expand-nonterminal/datum expr
    (dsl-lambda ()
+               (dsl-define f (f))
+               (f)))
+ '(dsl-lambda ()
+              (dsl-define-values (f) (f))
+              (f)))
+
+(check-equal?
+ (expand-nonterminal/datum expr
+   (dsl-lambda ()
                (dsl-define f (dsl-lambda (f) (f (g))))
                (dsl-begin
                 (dsl-define g (dsl-lambda () (f))))
@@ -64,7 +73,15 @@
               (dsl-begin
                (dsl-define-values (g) (dsl-lambda () (f))))
               (f)))
-   
+
+(check-equal?
+ (expand-nonterminal/datum expr
+   (dsl-letrec-values ([(a b c) (a b c d e f)]
+                       [(d e f) (a b c d e f)])
+     (a b c d e f)))
+ '(dsl-letrec-values ([(a b c) (a b c d e f)]
+                       [(d e f) (a b c d e f)])
+     (a b c d e f)))
 
 (check-exn
  #rx"dsl-define-values: identifier already defined"

--- a/tests/basic-langs/expr.rkt
+++ b/tests/basic-langs/expr.rkt
@@ -16,7 +16,7 @@
     #:binding [e ... (scope (bind v) ... b)]
       
     (let* (b:binding ...) e:expr)
-    #:binding (nest b e))
+    #:binding (nest b ... e))
 
   (nonterminal/nesting binding (nested)
     #:description "let* binding group"

--- a/tests/basic-langs/expr.rkt
+++ b/tests/basic-langs/expr.rkt
@@ -13,7 +13,7 @@
     (+ e1:expr e2:expr)
       
     (let ([v:var e:expr] ...) b:expr)
-    #:binding [e (scope (bind v) b)]
+    #:binding [e ... (scope (bind v) ... b)]
       
     (let* (b:binding ...) e:expr)
     #:binding (nest b e))

--- a/tests/basic-langs/mutual-recursion.rkt
+++ b/tests/basic-langs/mutual-recursion.rkt
@@ -19,7 +19,7 @@
     (< e1:expr e2:expr)
 
     (vars (v:var ...) e:expr)
-    #:binding (scope (bind v) e)
+    #:binding (scope (bind v) ... e)
    
     (do s:stmt ... e:expr))
 

--- a/tests/basic-langs/racket-macro.rkt
+++ b/tests/basic-langs/racket-macro.rkt
@@ -17,7 +17,7 @@
     (+ e1:expr e2:expr)
       
     (let ([v:var e:expr] ...) b:expr)
-    #:binding [e (scope (bind v) b)]))
+    #:binding [e ... (scope (bind v) ... b)]))
 
 (define-syntax let*
   (syntax-rules ()

--- a/tests/basic-langs/racket-var.rkt
+++ b/tests/basic-langs/racket-var.rkt
@@ -7,7 +7,7 @@
 (syntax-spec
   (nonterminal my-expr
    ((~literal let) ([x:racket-var e:racket-expr] ...) b:racket-expr)
-   #:binding (scope (bind x) b))
+   #:binding (scope (bind x) ... b))
 
   (host-interface/expression
     (eval-my-expr e:my-expr)

--- a/tests/basic-langs/simple-match.rkt
+++ b/tests/basic-langs/simple-match.rkt
@@ -27,7 +27,7 @@
     #:description "mylang match clause"
 
     [p:pat rhs:expr]
-    #:binding (nest-one p rhs))
+    #:binding (nest p rhs))
 
   (nonterminal/nesting pat (nested)
     #:description "mylang match pattern"
@@ -38,7 +38,7 @@
     (pempty)
                
     (pcons p1:pat p2:pat)
-    #:binding (nest-one p1 (nest-one p2 nested))))
+    #:binding (nest p1 (nest p2 nested))))
 
 (define-syntax define*
   (mylang-macro

--- a/tests/binding-operations.rkt
+++ b/tests/binding-operations.rkt
@@ -15,7 +15,7 @@
    #:binding (scope (bind x) e)
 
    (letrec ([x:var e:expr] ...) body:expr)
-   #:binding (scope (bind x) e (scope body)))
+   #:binding (scope (bind x) ... e ... (scope body)))
 
  (host-interface/definition
   (define-var v:var)

--- a/tests/dsls/baby-peg.rkt
+++ b/tests/dsls/baby-peg.rkt
@@ -39,7 +39,7 @@
 
   (host-interface/definitions
    (define-pegs [name:nonterm p:peg] ...)
-   #:binding (export name)
+   #:binding [(export name) ...]
    #'(begin (define name (lambda (s) (compile-peg p s)))
             ...))
 

--- a/tests/dsls/cmdline/cmdline.rkt
+++ b/tests/dsls/cmdline/cmdline.rkt
@@ -78,7 +78,7 @@
      ([option-name:racket-var opt:option] ...)
      (arg:arg-spec ...)
      rest:maybe-arg-spec)
-   #:binding [(export option-name) (re-export arg rest)]
+   #:binding [(export option-name) (re-export arg) (re-export rest)]
    #:lhs [#:with ([arg-name _] ...) (attribute arg)
           #:attr rest-name (syntax-parse (attribute rest) [[rest-name _] #'rest-name] [_ #f])
           #'(option-name ... arg-name ... (~? rest-name))]

--- a/tests/dsls/cmdline/cmdline.rkt
+++ b/tests/dsls/cmdline/cmdline.rkt
@@ -59,7 +59,7 @@
     #:allow-extension flag-macro
     ((~literal begin) f:flag ...+)
     [names:flag-names arg:arg-spec ... desc:string e:racket-expr]
-    #:binding (scope (import arg) e))
+    #:binding (scope (import arg) ... e))
 
   (nonterminal/exporting arg-spec
     (~> name:id #'[name identity/p])
@@ -78,7 +78,7 @@
      ([option-name:racket-var opt:option] ...)
      (arg:arg-spec ...)
      rest:maybe-arg-spec)
-   #:binding [(export option-name) (re-export arg) (re-export rest)]
+   #:binding [(export option-name) ... (re-export arg) ... (re-export rest)]
    #:lhs [#:with ([arg-name _] ...) (attribute arg)
           #:attr rest-name (syntax-parse (attribute rest) [[rest-name _] #'rest-name] [_ #f])
           #'(option-name ... arg-name ... (~? rest-name))]

--- a/tests/dsls/js/js.rkt
+++ b/tests/dsls/js/js.rkt
@@ -61,7 +61,7 @@
     (set! x:js-var e:js-expr)
     
     (function (x:js-var ...) body:js-stmt ...)
-    #:binding (scope (bind x) (scope (import body)))
+    #:binding (scope (bind x) ... (scope (import body ...)))
      
     (e:js-expr e*:js-expr ...))
   
@@ -80,11 +80,11 @@
     (return e:js-expr)
 
     (while c:js-expr body:js-stmt ...)
-    #:binding (scope (import body))
+    #:binding (scope (import body ...))
                         
     (if c:js-expr (b1:js-stmt ...) (b2:js-stmt ...))
-    #:binding [(scope (import b1)) (scope (import b2))]
-                        
+    #:binding [(scope (import b1 ...)) (scope (import b2 ...))]
+
     e:js-expr))
 
 

--- a/tests/dsls/js/js.rkt
+++ b/tests/dsls/js/js.rkt
@@ -61,7 +61,7 @@
     (set! x:js-var e:js-expr)
     
     (function (x:js-var ...) body:js-stmt ...)
-    #:binding (scope (bind x) ... (scope (import body ...)))
+    #:binding (scope (bind x) ... (scope (import body) ...))
      
     (e:js-expr e*:js-expr ...))
   
@@ -80,10 +80,10 @@
     (return e:js-expr)
 
     (while c:js-expr body:js-stmt ...)
-    #:binding (scope (import body ...))
+    #:binding (scope (import body) ...)
                         
     (if c:js-expr (b1:js-stmt ...) (b2:js-stmt ...))
-    #:binding [(scope (import b1 ...)) (scope (import b2 ...))]
+    #:binding [(scope (import b1) ...) (scope (import b2) ...)]
 
     e:js-expr))
 

--- a/tests/dsls/match.rkt
+++ b/tests/dsls/match.rkt
@@ -23,7 +23,7 @@
     #:binding (scope (import p)))
   (nonterminal clause
     [p:pat body:racket-expr ...+]
-    #:binding (scope (import p) body))
+    #:binding (scope (import p) body ...))
   (host-interface/expression
     (match target:racket-expr c:clause ...)
     #'(with-reference-compilers ([pat-var immutable-reference-compiler])

--- a/tests/dsls/miniclass/class.rkt
+++ b/tests/dsls/miniclass/class.rkt
@@ -55,7 +55,7 @@
 
   (host-interface/expression
     (class e:class-form ...)
-    #:binding (scope (import e ...))
+    #:binding (scope (import e) ...)
     (define-values (defns fields exprs) (group-class-decls (splice-begins (attribute e))))
     (compile-class-body defns fields exprs)))
 

--- a/tests/dsls/miniclass/class.rkt
+++ b/tests/dsls/miniclass/class.rkt
@@ -46,7 +46,7 @@
                         #:binding (export m)
 
                         ((~literal define-syntaxes) (x:racket-macro ...) e:expr)
-                        #:binding (export-syntaxes x e)
+                        #:binding (export-syntaxes x ... e)
 
                         ((~literal begin) e:class-form ...)
                         #:binding [(re-export e) ...]

--- a/tests/dsls/miniclass/class.rkt
+++ b/tests/dsls/miniclass/class.rkt
@@ -41,7 +41,7 @@
   (nonterminal/exporting class-form
                         #:allow-extension racket-macro
                         (field name:field-var ...)
-                        #:binding (export name)
+                        #:binding [(export name) ...]
                         ((~literal define-values) (m:method-var) (lambda:lambda-id (arg:id ...) body:racket-expr ...))
                         #:binding (export m)
 
@@ -49,13 +49,13 @@
                         #:binding (export-syntaxes x e)
 
                         ((~literal begin) e:class-form ...)
-                        #:binding (re-export e)
+                        #:binding [(re-export e) ...]
 
                         e:racket-expr)
 
   (host-interface/expression
     (class e:class-form ...)
-    #:binding (scope (import e))
+    #:binding (scope (import e ...))
     (define-values (defns fields exprs) (group-class-decls (splice-begins (attribute e))))
     (compile-class-body defns fields exprs)))
 

--- a/tests/dsls/minikanren-binding-space-compile.rkt
+++ b/tests/dsls/minikanren-binding-space-compile.rkt
@@ -31,7 +31,7 @@
   (host-interface/expression
     (run n:expr (qvar:term-variable ...)
       g:goal)
-    #:binding (scope (bind qvar) g)
+    #:binding (scope (bind qvar) ... g)
 
     #`(let ([qvar (gensym)] ...)
         #,(compile-goal #'g))))

--- a/tests/dsls/minikanren-binding-space.rkt
+++ b/tests/dsls/minikanren-binding-space.rkt
@@ -57,7 +57,7 @@
     (conj2 g1:goal g2:goal)
   
     (fresh1 (x:term-variable ...) b:goal)
-    #:binding (scope (bind x) b)
+    #:binding (scope (bind x) ... b)
 
     (#%rel-app r:relation-name t:term ...+)
 

--- a/tests/dsls/minikanren-compile-defs.rkt
+++ b/tests/dsls/minikanren-compile-defs.rkt
@@ -29,7 +29,7 @@
   (host-interface/expression
     (run n:expr (qvar:term-variable ...)
       g:goal ...)
-    #:binding (scope (bind qvar) g)
+    #:binding (scope (bind qvar) ... g ...)
   
     #'(void))
 
@@ -40,18 +40,18 @@
 
   (host-interface/definitions
     (define-relation (name:relation-name arg:term-variable ...) body:goal)
-    #:binding [(export name) (scope (bind arg) body)]
+    #:binding [(export name) (scope (bind arg) ... body)]
     #'(define tmp 5)))
 
 
 (syntax-spec
  (nonterminal/exporting mk-def
    (define-relation2 (name:relation-name arg:term-variable ...) body:goal)
-   #:binding [(export name) (scope (bind arg) body)])
+   #:binding [(export name) (scope (bind arg) ... body)])
 
  (host-interface/definitions
    (mk-defs d:mk-def ...)
-   #:binding (re-export d)
+   #:binding [(re-export d) ...]
    #'(define tmp 5)))
 
 

--- a/tests/dsls/minikanren-compile.rkt
+++ b/tests/dsls/minikanren-compile.rkt
@@ -27,7 +27,7 @@
   (host-interface/expression
     (run n:expr (qvar:term-variable ...)
       g:goal ...)
-    #:binding (scope (bind qvar) g)
+    #:binding (scope (bind qvar) ... g ...)
 
     #'(void))
 

--- a/tests/dsls/minikanren-rs2e/mk.rkt
+++ b/tests/dsls/minikanren-rs2e/mk.rkt
@@ -59,6 +59,7 @@
     #:binding (scope (bind x) b)
 
     (project (x:term-variable ...) e:racket-expr ...)
+    #:binding [x ...]
     
     (ifte g1:goal g2:goal g3:goal)
     (once g:goal)
@@ -128,7 +129,7 @@
 (syntax-spec
   (host-interface/definition
     (core-defrel (name:relation-name x:term-variable ...) g:goal)
-    #:binding [(export name) (scope (bind x) g)]
+    #:binding [(export name) (scope (bind x) ... g)]
    
     #:lhs
     [(symbol-table-set!
@@ -150,7 +151,7 @@
     #`(let ([q (var 'q)])
         (map (reify q)
              (run-goal n (compile-goal g)))))
-
+  
   (host-interface/expression
     (goal-expression g:goal)
     #`(goal-value (compile-goal g))))

--- a/tests/dsls/minikanren.rkt
+++ b/tests/dsls/minikanren.rkt
@@ -49,7 +49,7 @@
    (conj2 g1:goal g2:goal)
   
    (fresh1 (x:term-variable ...) b:goal)
-   #:binding (scope (bind x) b)
+   #:binding (scope (bind x) ... b)
 
    (#%rel-app r:relation-name t:term ...+)
 

--- a/tests/dsls/peg.rkt
+++ b/tests/dsls/peg.rkt
@@ -18,7 +18,7 @@
     (list e:expr ...))
 
   (nonterminal peg-top
-    n:peg #:binding (nest-one n []))
+    n:peg #:binding (nest n []))
   
   (nonterminal/nesting peg (tail)
     #:description "PEG expression"
@@ -28,29 +28,29 @@
     (eps)               ; can't just be `eps` yet.
     
     (seq e1:peg e2:peg)
-    #:binding (nest-one e1 (nest-one e2 tail))
+    #:binding (nest e1 (nest e2 tail))
     
     (alt e1:peg e2:peg)
-    #:binding [(nest-one e1 []) (nest-one e2 [])]
+    #:binding [(nest e1 []) (nest e2 [])]
     
     (repeat e:peg)      ; *
-    #:binding (nest-one e [])
+    #:binding (nest e [])
     
     (not e:peg)         ; !
-    #:binding (nest-one e [])
+    #:binding (nest e [])
     
     (bind x:var e:peg)  ; :
-    #:binding (scope (bind x) (nest-one e []) tail)
+    #:binding (scope (bind x) (nest e []) tail)
     
     (=> pe:peg e:expr)
-    #:binding (nest-one pe e)
+    #:binding (nest pe e)
     
     (text e:expr) ; right now these are referring to the expr syntax class. Need escape to Racket...
     
     (char e:expr)
     (token e:expr)
     (src-span v:var e:peg)
-    #:binding (scope (nest-one e []))
+    #:binding (scope (nest e []))
     
     ;; can't do implicit #%peg-datum yet.
     

--- a/tests/dsls/peg/core.rkt
+++ b/tests/dsls/peg/core.rkt
@@ -69,7 +69,7 @@
     (text e:text-expr)
 
     (=> ps:peg-seq e:racket-expr)
-    #:binding (nest-one ps e)
+    #:binding (nest ps e)
 
     (~> n:id #'(#%nonterm-ref n))
     (#%nonterm-ref n:nonterm))
@@ -85,34 +85,34 @@
     (~> p:ref-id #'(bind p.var p.ref))
 
     (bind v:var ps:peg-seq)
-    #:binding (nest-one ps (scope (bind v) tail))
+    #:binding (nest ps (scope (bind v) tail))
 
     (seq ps1:peg-seq ps2:peg-seq)
-    #:binding (nest-one ps1 (nest-one ps2 tail))
+    #:binding (nest ps1 (nest ps2 tail))
 
     (alt e1:peg e2:peg)
 
     (? e:peg-seq)
-    #:binding (nest-one e tail)
+    #:binding (nest e tail)
 
     (plain-alt e1:peg-seq e2:peg-seq)
-    #:binding (nest-one e1 (nest-one e2 tail))
+    #:binding (nest e1 (nest e2 tail))
 
     (* ps:peg-seq)
-    #:binding (nest-one ps tail)
+    #:binding (nest ps tail)
 
     (src-span v:var ps:peg-seq)
-    #:binding (scope (bind v) (nest-one ps tail))
+    #:binding (scope (bind v) (nest ps tail))
 
     pe:peg-el)
 
   (nonterminal peg
     ps:peg-seq
-    #:binding (nest-one ps []))
+    #:binding (nest ps []))
 
   (host-interface/definitions
    (define-pegs [name:nonterm p:peg] ...)
-   #:binding (export name)
+   #:binding [(export name) ...]
    (run-leftrec-check! (attribute name) (attribute p))
    #'(begin (define name (lambda (in) (with-reference-compilers ([var immutable-reference-compiler])
                                         (compile-peg p in))))

--- a/tests/dsls/peg2.rkt
+++ b/tests/dsls/peg2.rkt
@@ -21,29 +21,29 @@
     (text e:racket-expr)
     
     (=> ps:peg-seq e:racket-expr)
-    #:binding (nest-one ps e))
+    #:binding (nest ps e))
 
   (nonterminal/nesting peg-seq (tail)
     #:description "PEG expression"
     #:allow-extension peg-macro
     
     (bind v:var ps:peg-seq)
-    #:binding (scope (bind v) (nest-one ps tail))
+    #:binding (scope (bind v) (nest ps tail))
     
     (seq ps1:peg-seq ps2:peg-seq)
-    #:binding (nest-one ps1 (nest-one ps2 tail))
+    #:binding (nest ps1 (nest ps2 tail))
 
     (repeat ps:peg-seq)
-    #:binding (nest-one ps tail)
+    #:binding (nest ps tail)
 
     (src-span v:var ps:peg-seq)
-    #:binding (scope (bind v) (nest-one ps tail))
+    #:binding (scope (bind v) (nest ps tail))
 
     pe:peg-el)
 
   (nonterminal peg   
     ps:peg-seq
-    #:binding (nest-one ps [])))
+    #:binding (nest ps [])))
 
 (require racket/match)
 

--- a/tests/dsls/qi-core.rkt
+++ b/tests/dsls/qi-core.rkt
@@ -8,7 +8,7 @@
     #:binding (scope (bind v) nested)
 
     (thread f:binding-floe ...)
-    #:binding (nest f nested)
+    #:binding (nest f ... nested)
 
     f:simple-floe
     #:binding [f nested])
@@ -20,7 +20,7 @@
 
   (nonterminal floe
     f:binding-floe
-    #:binding (nest-one f [])))
+    #:binding (nest f [])))
 
 (void
  (expand-nonterminal/datum floe

--- a/tests/dsls/simply-typed-lambda-calculus.rkt
+++ b/tests/dsls/simply-typed-lambda-calculus.rkt
@@ -36,7 +36,7 @@
     (rkt e:racket-expr (~datum :) t:type)
 
     (block d:typed-definition-or-expr ... e:typed-expr)
-    #:binding (scope (import d ...) e)
+    #:binding (scope (import d) ... e)
 
     ; rewrite for tagging applications
     (~> (fun arg ...)

--- a/tests/dsls/simply-typed-lambda-calculus.rkt
+++ b/tests/dsls/simply-typed-lambda-calculus.rkt
@@ -22,11 +22,11 @@
     n:number
 
     (#%lambda ([x:typed-var (~datum :) t:type] ...) body:typed-expr)
-    #:binding (scope (bind x) body)
+    #:binding (scope (bind x) ... body)
     (#%app fun:typed-expr arg:typed-expr ...)
 
     (#%let ([x:typed-var e:typed-expr] ...) body:typed-expr)
-    #:binding (scope (bind x) body)
+    #:binding (scope (bind x) ... body)
 
     ; type annotation
     (~> (e (~datum :) t)
@@ -36,7 +36,7 @@
     (rkt e:racket-expr (~datum :) t:type)
 
     (block d:typed-definition-or-expr ... e:typed-expr)
-    #:binding (scope (import d) e)
+    #:binding (scope (import d ...) e)
 
     ; rewrite for tagging applications
     (~> (fun arg ...)
@@ -50,7 +50,7 @@
     (#%define x:typed-var t:type e:typed-expr)
     #:binding (export x)
     (begin defn:typed-definition-or-expr ...+)
-    #:binding (re-export defn)
+    #:binding [(re-export defn) ...]
     e:typed-expr)
   (host-interface/expression
    (stlc/expr e:typed-expr)
@@ -63,7 +63,7 @@
    #`'#,t-datum)
   (host-interface/definitions
    (stlc body:typed-definition-or-expr ...+)
-   #:binding (re-export body)
+   #:binding [(re-export body) ...]
    (type-check-defn-or-expr/pass1 #'(begin body ...))
    (type-check-defn-or-expr/pass2 #'(begin body ...))
    #'(compile-defn-or-expr/top (begin body ...)))

--- a/tests/dsls/simply-typed-lambda-calculus.rkt
+++ b/tests/dsls/simply-typed-lambda-calculus.rkt
@@ -69,7 +69,7 @@
    #'(compile-defn-or-expr/top (begin body ...)))
   (host-interface/definitions
    (stlc/module-begin body:typed-definition-or-expr ...+)
-   #:binding (re-export body)
+   #:binding [(re-export body) ...]
    (type-check-defn-or-expr/pass1 #'(begin body ...))
    (type-check-defn-or-expr/pass2 #'(begin body ...))
    (define/syntax-parse (name ...) (sequence->list (sequence-map compiled-from (in-symbol-set (definition-names #'(begin body ...))))))

--- a/tests/dsls/state-machine-for-tutorial.rkt
+++ b/tests/dsls/state-machine-for-tutorial.rkt
@@ -24,11 +24,11 @@
         body:racket-expr
         ...
         ((~datum goto) next-state-name:state-name))
-    #:binding (scope (bind arg) body))
+    #:binding (scope (bind arg) ... body ...))
 
   (host-interface/expression
     (machine #:initial initial-state:state-name s:state-spec ...)
-    #:binding (scope (import s) initial-state)
+    #:binding (scope (import s ...) initial-state)
 
     (check-for-inaccessible-states #'initial-state (attribute s))
     #'(compile-machine initial-state s ...)))

--- a/tests/dsls/state-machine-for-tutorial.rkt
+++ b/tests/dsls/state-machine-for-tutorial.rkt
@@ -28,7 +28,7 @@
 
   (host-interface/expression
     (machine #:initial initial-state:state-name s:state-spec ...)
-    #:binding (scope (import s ...) initial-state)
+    #:binding (scope (import s) ... initial-state)
 
     (check-for-inaccessible-states #'initial-state (attribute s))
     #'(compile-machine initial-state s ...)))

--- a/tests/dsls/state-machine-oo/state-machine.rkt
+++ b/tests/dsls/state-machine-oo/state-machine.rkt
@@ -9,7 +9,7 @@
 
   (host-interface/expression
     (machine #:initial-state s:state-name d:machine-decl ...)
-    #:binding (scope (import d) s)
+    #:binding (scope (import d ...) s)
     #'(compile-machine s d ...))
   
   (nonterminal/exporting machine-decl
@@ -23,4 +23,4 @@
     (on (evt:id arg:racket-var ...)
       e:racket-expr ...
       ((~datum ->) s:state-name))
-    #:binding (scope (bind arg) e)))
+    #:binding (scope (bind arg) ... e ...)))

--- a/tests/dsls/state-machine-oo/state-machine.rkt
+++ b/tests/dsls/state-machine-oo/state-machine.rkt
@@ -9,7 +9,7 @@
 
   (host-interface/expression
     (machine #:initial-state s:state-name d:machine-decl ...)
-    #:binding (scope (import d ...) s)
+    #:binding (scope (import d) ... s)
     #'(compile-machine s d ...))
   
   (nonterminal/exporting machine-decl

--- a/tests/dsls/statecharts/statecharts.rkt
+++ b/tests/dsls/statecharts/statecharts.rkt
@@ -14,24 +14,24 @@
 
   (nonterminal machine-spec
     [#:initial initial-state:state-name s:machine-element-spec ...]
-    #:binding (scope (import s) initial-state))
+    #:binding (scope (import s) ... initial-state))
   
   (nonterminal/exporting machine-element-spec
     (data v:data-var e:expr)
     #:binding (export v)
 
     (state n:state-name #:nested-machine nm:machine-name e:event-spec ...)
-    #:binding [(export n) nm e]
+    #:binding [(export n) nm e ...]
     
     (state n:state-name e:event-spec ...)
-    #:binding [(export n) e])
+    #:binding [(export n) e ...])
 
   (nonterminal event-spec
     (on (evt:id arg:local-var ...) #:when guard:racket-expr b:action-spec ... t:transition-spec)
-    #:binding (scope (bind arg) guard b)
+    #:binding (scope (bind arg) ... guard b ...)
     
     (on (evt:id arg:local-var ...) b:action-spec ... t:transition-spec)
-    #:binding (scope (bind arg) b))
+    #:binding (scope (bind arg) ... b ...))
 
   (nonterminal/nesting binding (nested)    
     [v:local-var e:racket-expr]
@@ -39,7 +39,7 @@
   
   (nonterminal action-spec
     ((~literal let*) (b:binding ...) a:action-spec ...)
-    #:binding (nest b a)
+    #:binding (nest b ... [a ...])
     
     (set v:data-var e:racket-expr)
 

--- a/tests/dsls/stlc-on-typed-racket.rkt
+++ b/tests/dsls/stlc-on-typed-racket.rkt
@@ -19,7 +19,7 @@
    #'(compile-expr/top e))
   (host-interface/definitions
    (stlc body:typed-definition-or-expr ...+)
-   #:binding (re-export body)
+   #:binding [(re-export body) ...]
    (type-check-defn-or-expr/pass1 #'(begin body ...))
    (type-check-defn-or-expr/pass2 #'(begin body ...))
    #'(compile-defn-or-expr (begin body ...))))

--- a/tests/dsls/tiny-hdl/hdl.rkt
+++ b/tests/dsls/tiny-hdl/hdl.rkt
@@ -23,7 +23,7 @@
     #:binding (export name)
 
     (architecture name:arch-name e:entity-name stmt:statement ...)
-    #:binding [(export name) (scope (import stmt))])
+    #:binding [(export name) (scope (import stmt) ...)])
   
   (nonterminal port-spec
     (m:mode name:id))
@@ -57,7 +57,7 @@
 
   (host-interface/definitions
     (begin-tiny-hdl t:top-item ...)
-    #:binding (re-export t)
+    #:binding [(re-export t) ...]
 
     (for ([t (attribute t)])
       (register-entities! t))

--- a/tests/dsls/typed-peg/core.rkt
+++ b/tests/dsls/typed-peg/core.rkt
@@ -66,7 +66,7 @@
     (text e:text-expr)
 
     (=> ps:peg-seq e:racket-expr)
-    #:binding (nest-one ps e)
+    #:binding (nest ps e)
 
     (~> n:id #'(#%nonterm-ref n))
     (#%nonterm-ref n:nonterm))
@@ -82,34 +82,34 @@
     (~> p:ref-id #'(bind p.var p.ref))
 
     (bind v:var ps:peg-seq)
-    #:binding (nest-one ps (scope (bind v) tail))
+    #:binding (nest ps (scope (bind v) tail))
 
     (seq ps1:peg-seq ps2:peg-seq)
-    #:binding (nest-one ps1 (nest-one ps2 tail))
+    #:binding (nest ps1 (nest ps2 tail))
 
     (alt e1:peg e2:peg)
 
     (? e:peg-seq)
-    #:binding (nest-one e tail)
+    #:binding (nest e tail)
 
     (plain-alt e1:peg-seq e2:peg-seq)
-    #:binding (nest-one e1 (nest-one e2 tail))
+    #:binding (nest e1 (nest e2 tail))
 
     (* ps:peg-seq)
-    #:binding (nest-one ps tail)
+    #:binding (nest ps tail)
 
     (src-span v:var ps:peg-seq)
-    #:binding (scope (bind v) (nest-one ps tail))
+    #:binding (scope (bind v) (nest ps tail))
 
     pe:peg-el)
 
   (nonterminal peg
     ps:peg-seq
-    #:binding (nest-one ps []))
+    #:binding (nest ps []))
 
   (host-interface/definitions
    (define-pegs [name:nonterm p:peg] ...)
-   #:binding (export name)
+   #:binding [(export name) ...]
    #'(begin (define name (lambda ([in : text-rep]) (with-reference-compilers ([var immutable-reference-compiler])
                                         (compile-peg p in))))
             ...))

--- a/tests/errors.rkt
+++ b/tests/errors.rkt
@@ -149,15 +149,23 @@
      #:binding (scope e (import d)))))
 
 (check-decl-error
- #rx"nonterminal: only one import binding group may appear in a scope"
+ #rx"import cannot contain more than one ellipsis"
  (syntax-spec
-   (binding-class var)
-   (nonterminal/exporting def
-     (define x:var e:expr)
-     #:binding [(export x) e])
+   (nonterminal/exporting decl
+     ())
    (nonterminal expr
-     (block d1:def d2:def)
-     #:binding (scope (import d1) (import d2)))))
+     (m (d:decl (... ...)) (... ...))
+     #:binding (import d (... ...) (... ...)))))
+
+(check-decl-error
+ #rx"import cannot contain more than one ellipsis"
+ (syntax-spec
+   (nonterminal/exporting decl
+     ())
+   (nonterminal expr
+     (m (d:decl (... ...)) (... ...))
+     ; this one tests that we get the error even on [(import ...) ...] ~> (import ... ...)
+     #:binding [(import d (... ...)) (... ...)])))
 
 (check-decl-error
  #rx"exports must appear first in a exporting spec"

--- a/tests/errors.rkt
+++ b/tests/errors.rkt
@@ -168,6 +168,16 @@
      #:binding [(import d ...) ...])))
 
 (check-decl-error
+ #rx"nest cannot contain more than one ellipsis"
+ (syntax-spec
+   (nonterminal/nesting binding (nested)
+     ())
+   (nonterminal expr
+     (m (b:binding ...) ...)
+     ; this one tests that we get the error even on [(import ...) ...] ~> (import ... ...)
+     #:binding (nest d ... ... []))))
+
+(check-decl-error
  #rx"exports must appear first in a exporting spec"
  (syntax-spec
    (binding-class var)

--- a/tests/errors.rkt
+++ b/tests/errors.rkt
@@ -130,6 +130,17 @@
      #:binding (import d))))
 
 (check-decl-error
+ #rx"nonterminal: import binding groups must occur within a scope"
+ (syntax-spec
+   (binding-class var #:description "var")
+   (nonterminal/exporting def
+     (define x:var e:expr)
+     #:binding [(export x) e])
+   (nonterminal expr
+     (block d:def)
+     #:binding [(import d)])))
+
+(check-decl-error
  #rx"nonterminal: bindings must appear first within a scope"
  (syntax-spec
    (binding-class var)

--- a/tests/errors.rkt
+++ b/tests/errors.rkt
@@ -158,6 +158,18 @@
      ; this one tests that we get the error even on [(import ...) ...] ~> (import ... ...)
      #:binding (nest d ... ... []))))
 
+
+(check-decl-error
+ #rx"cannot mix different binding spec categories inside of ellipses"
+ (syntax-spec
+   (nonterminal my-expr
+     (my-letrec ([x:racket-var e:racket-expr] ...) body:racket-expr)
+     #:binding (scope [(bind x) e] ... body))
+   (nonterminal expr
+     (m (b:binding ...) ...)
+     ; this one tests that we get the error even on [(import ...) ...] ~> (import ... ...)
+     #:binding (nest d ... ... []))))
+
 (check-decl-error
  #rx"exports must appear first in a exporting spec"
  (syntax-spec

--- a/tests/errors.rkt
+++ b/tests/errors.rkt
@@ -103,7 +103,7 @@
 
 
 (check-decl-error
- #rx"nonterminal: exports may only occur at the top-level of a exporting binding spec"
+ #rx"nonterminal: exports may only occur at the top-level of an exporting binding spec"
  (syntax-spec
    (binding-class var #:description "var")
    (nonterminal expr

--- a/tests/errors.rkt
+++ b/tests/errors.rkt
@@ -223,6 +223,13 @@
      (foo a:racket-var)
      #:binding [a ...])))
 
+(check-decl-error
+ #rx"nonterminal/nesting: too many ellipses for pattern variable in binding spec"
+ (syntax-spec
+   (nonterminal/nesting expr (nested)
+     (foo a:racket-var)
+     #:binding (scope (bind a) nested ...))))
+
 ;;
 ;; Valid definitions used to exercise errors
 ;;

--- a/tests/errors.rkt
+++ b/tests/errors.rkt
@@ -149,25 +149,6 @@
      #:binding (scope e (import d)))))
 
 (check-decl-error
- #rx"import cannot contain more than one ellipsis"
- (syntax-spec
-   (nonterminal/exporting decl
-     ())
-   (nonterminal expr
-     (m (d:decl ...) ...)
-     #:binding (import d ... ...))))
-
-(check-decl-error
- #rx"import cannot contain more than one ellipsis"
- (syntax-spec
-   (nonterminal/exporting decl
-     ())
-   (nonterminal expr
-     (m (d:decl ...) ...)
-     ; this one tests that we get the error even on [(import ...) ...] ~> (import ... ...)
-     #:binding [(import d ...) ...])))
-
-(check-decl-error
  #rx"nest cannot contain more than one ellipsis"
  (syntax-spec
    (nonterminal/nesting binding (nested)

--- a/tests/group-ellipsis.rkt
+++ b/tests/group-ellipsis.rkt
@@ -9,6 +9,8 @@
   (nonterminal my-expr
     (my-let ([x:racket-var e:racket-expr] ...) body:racket-expr ...)
     #:binding [[e] ... (scope [(bind x)] ... [body] ...)]
+    (my-weird-let (d1:my-exporting ...) (d2:my-exporting ...) ([x:racket-var e:racket-expr] ...) b:racket-expr)
+    #:binding (scope [(bind x) ... (import d2) ...] (import d1) ...)
     (my-imporing d:my-exporting ...)
     #:binding (scope [(import d)] ...))
  (nonterminal/exporting my-exporting

--- a/tests/group-ellipsis.rkt
+++ b/tests/group-ellipsis.rkt
@@ -2,7 +2,7 @@
 
 ; testing edge cases with ellipses and groups
 
-(require "../testing.rkt")
+(require "../main.rkt")
 
 ; the test is just that this compiles
 (syntax-spec
@@ -16,3 +16,9 @@
  (nonterminal/exporting my-exporting
    (my-define-values (x:racket-var ...))
    #:binding [[(export x)] ...]))
+
+; and this---here we're making sure ...+ works just like ... for depth checking
+(syntax-spec
+  (nonterminal/exporting my-def
+    (my-def x:racket-var ...+ e:racket-expr)
+    #:binding [(export x) ...]))

--- a/tests/group-ellipsis.rkt
+++ b/tests/group-ellipsis.rkt
@@ -1,0 +1,16 @@
+#lang racket/base
+
+; testing edge cases with ellipses and groups
+
+(require "../testing.rkt")
+
+; the test is just that this compiles
+(syntax-spec
+  (nonterminal my-expr
+    (my-let ([x:racket-var e:racket-expr] ...) body:racket-expr ...)
+    #:binding [[e] ... (scope [(bind x)] ... [body] ...)]
+    (my-imporing d:my-exporting ...)
+    #:binding (scope [(import d)] ...))
+ (nonterminal/exporting my-exporting
+   (my-define-values (x:racket-var ...))
+   #:binding [[(export x)] ...]))

--- a/tests/multi-import.rkt
+++ b/tests/multi-import.rkt
@@ -1,0 +1,32 @@
+#lang racket/base
+
+; testing the combining of multiple imports into a single import group
+
+(require "../testing.rkt")
+
+(syntax-spec
+  (nonterminal/exporting defn
+    ((~literal define) x:racket-var e:racket-expr)
+    #:binding [(export x)])
+
+  (host-interface/expression
+    (double-local ([d1:defn ...] [d2:defn ...]) body:racket-expr)
+    #:binding (scope (import d1 ...) (import d2 ...) body)
+    #'(compile-expr ([d1 ...] [d2 ...]) body)))
+
+(define-syntax compile-expr
+  (syntax-parser
+    #:literals (define)
+    [(_ ([(define x1 e1) ...] [(define x2 e2) ...]) body)
+     #'(let ()
+         (define x1 e1)
+         ...
+         (define x2 e2)
+         ...
+         body)]))
+
+(check-equal?
+ (double-local ([(define odd? (lambda (n) (if (zero? n) #f (even? (sub1 n)))))]
+                [(define even? (lambda (n) (or (zero? n) (odd? (sub1 n)))))])
+               (odd? 3))
+ #t)

--- a/tests/multi-import.rkt
+++ b/tests/multi-import.rkt
@@ -11,17 +11,22 @@
 
   (host-interface/expression
     (double-local ([d1:defn ...] [d2:defn ...]) body:racket-expr)
-    #:binding (scope (import d1 ...) (import d2 ...) body)
-    #'(compile-expr ([d1 ...] [d2 ...]) body)))
+    #:binding (scope (import d1) ... (import d2) ... body)
+    #'(compile-expr ([d1 ...] [d2 ...]) body))
+
+  (host-interface/expression
+    (many-local ([d:defn ...] ...) body:racket-expr)
+    ; this group is unnecessary, but we want to test the behavior of ellipsized groups with imports
+    #:binding (scope [[[[(import d)]] ...] ...] body)
+    #'(compile-expr ([d ...] ...) body)))
 
 (define-syntax compile-expr
   (syntax-parser
     #:literals (define)
-    [(_ ([(define x1 e1) ...] [(define x2 e2) ...]) body)
+    [(_ ([(define x e1) ...] ...) body)
      #'(let ()
-         (define x1 e1)
+         (define x e1)
          ...
-         (define x2 e2)
          ...
          body)]))
 

--- a/tests/nest-use-site-scope.rkt
+++ b/tests/nest-use-site-scope.rkt
@@ -17,7 +17,7 @@
 
   (host-interface/expression
     (my-match [p:pat e:dsl-expr])
-    #:binding (nest-one p e)
+    #:binding (nest p e)
     #''success))
 
 ;; I'm not sure why, but the problem didn't occur at the module level. Perhaps
@@ -31,13 +31,13 @@
 (syntax-spec
   (nonterminal my-expr
     (block d:my-def ...)
-    #:binding (scope (import d)))
+    #:binding (scope (import d ...)))
  
   (nonterminal/exporting my-def
     ((~literal define-syntax) x:pat-macro e:expr)
     #:binding (export-syntax x e)
     ((~literal my-match) [p:pat e:dsl-expr])
-    #:binding (nest-one p e))
+    #:binding (nest p e))
  
   (host-interface/expression
     (eval-my-expr e:my-expr)

--- a/tests/nest-use-site-scope.rkt
+++ b/tests/nest-use-site-scope.rkt
@@ -31,7 +31,7 @@
 (syntax-spec
   (nonterminal my-expr
     (block d:my-def ...)
-    #:binding (scope (import d ...)))
+    #:binding (scope [(import d) ...]))
  
   (nonterminal/exporting my-def
     ((~literal define-syntax) x:pat-macro e:expr)

--- a/tests/nested-with-reference-compilers.rkt
+++ b/tests/nested-with-reference-compilers.rkt
@@ -11,7 +11,7 @@
   (binding-class blue-var)
   (nonterminal blue-expr
     ((~literal let) ([x:blue-var e:racket-expr] ...) b:racket-expr)
-    #:binding (scope (bind x) b))
+    #:binding (scope (bind x) ... b))
 
   (host-interface/expression
     (blue e:blue-expr)
@@ -23,7 +23,7 @@
   (binding-class red-var)
   (nonterminal red-expr
     ((~literal let) ([x:red-var e:racket-expr] ...) b:racket-expr)
-    #:binding (scope (bind x) b))
+    #:binding (scope (bind x) ... b))
 
   (host-interface/expression
     (red e:red-expr)

--- a/tests/symbol-collections.rkt
+++ b/tests/symbol-collections.rkt
@@ -51,14 +51,14 @@
 (syntax-spec
  (nonterminal/exporting bind-expr
   (bind x:my-var ...)
-  #:binding (export x))
+  #:binding [(export x) ...])
  (nonterminal set-op-expr
    (intersection (x:my-var ...) (y:my-var ...))
    (union (x:my-var ...) (y:my-var ...))
    (subtract (x:my-var ...) (y:my-var ...)))
  (host-interface/definitions
   (my-define x:my-var ...)
-  #:binding (export x)
+  #:binding [(export x) ...]
   #'(begin (define x 1) ...))
  (host-interface/expression
   (set-op e:set-op-expr)


### PR DESCRIPTION
This PR introduces an ellipsis syntax in binding specs, and makes them mandatory. Spec variable references in binding specs must occur at the same ellipsis depth as their syntax spec counterparts.

## Motivation

Ellipses help control the binding structure of syntax with sequences. For example:

```racket
#lang racket

(require syntax-spec-v2)

(syntax-spec
  (binding-class my-var)
  (nonterminal my-expr
    x:my-var
    n:number
    (my-let ([x:my-var e:my-expr] ...) body:my-expr ...)
    #:binding (scope (bind x) body)
    (my-cond [test:my-expr #:as x:my-var body:my-expr] ...)
    #:binding (scope (bind x) body))
  (host-interface/expression (my-dsl e:my-expr)
                             #`'#,((nonterminal-expander my-expr) #'e)))

; dsl-expansion should error saying x is unbound in second branch
(my-dsl (my-cond [1 #:as x 1]
                 [2 #:as y x]))

```

In the above example, we're defining a version of `cond` that binds the result of the test in the branch's body. In the face of sequences of syntax, `syntax-spec` infers the binding structure automatically. However, it cannot distinguish between this cond-like binding structure and the let-like binding structure. In both cases, there is a list of identifiers being bound in a list of bodies. But should each identifier be bound only in the corresponding body? Or all bodies? The inferred structure binds each variable in all bodies, which is wrong in this case.

To allow users more control over binding structure, we should add ellipses to binding specs.

Here is the example re-written with ellipses:

```racket
#lang racket

(require syntax-spec)

(syntax-spec
  (binding-class my-var)
  (nonterminal my-expr
    x:my-var
    n:number
    (my-let ([x:my-var e:my-expr] ...) body:my-expr ...)
    #:binding (scope (bind x) ... body ...)
    (my-cond [test:my-expr #:as x:my-var body:my-expr] ...)
    #:binding [(scope (bind x) body) ...])
  (host-interface/expression (my-dsl e:my-expr)
                             #`'#,((nonterminal-expander my-expr) #'e)))

(my-dsl (my-cond [1 #:as x 1]
                 [2 #:as y x]))
```

The placement of ellipses in binding specs distinguishes between the two cases.

I have verified that this properly treats the reference to `x` in the preceding example as unbound in the ellipsis implementation.

## Interaction with nesting

Ellipses also change the syntax for `nest`:

```racket
(syntax-spec
  (binding-class my-var)
  (nonterminal my-expr
    n:number
    x:my-var
    (my-let* (b:binding-pair ...) body:my-expr)
    #:binding (nest b ... body))
  (nonterminal/nesting binding-pair (nested)
    [x:my-var e:my-expr]
    #:binding (scope (bind x) nested)))
```

Note that `nest` has internal ellipses for the binding pair sequence. This declares that the sequence is to be folded over.

`nest-one` no longer exists. Just use `nest` with no ellipses on the first argument. So `(nest-one b e)` is now written as `(nest b e)`.

## Interaction with -syntaxes bindings forms

The `export-syntaxes` and `bind-syntaxes` forms create simultaneous syntax bindings for a number of identifiers, using the multiple values returned from a single compile-time expression, similar to Racket's `define-syntaxes`.

These forms now have internal ellipses for the sequence of identifiers:

```racket
(syntax-spec
  (nonterminal/exporting block-form
    #:allow-extension racket-macro

    ((~literal define-values) (x:racket-var ...) e:racket-expr)
    #:binding [(export x) ...]

    ((~literal define-syntaxes) (x:racket-macro ...) e:expr)
    #:binding (export-syntaxes x ... e)

   ((~literal begin) d:block-form ...+)
   #:binding [(re-export d) ...]

    e:racket-expr))
```

## Drawbacks

Syntaxes like `my-cond` where the current implicit behavior is incorrect have been rare in practice.

Requiring ellipses everywhere makes many binding specs somewhat more verbose. For example:

```
(let* (b:binding-group ...) body:action ...)
#:binding (nest b ... [body ...]))
```

vs the previous

```
(let* (b:binding-group ...) body:action ...)
#:binding (nest b body))
```

Or,

```
(letrec-syntaxes ([(v:racket-macro ...) e:expr] ...) b:racket-like-expr)
#:binding (scope (bind-syntaxes v ... e) ... b)
```

vs

```
(letrec-syntaxes ([(v:racket-macro ...) e:expr] ...) b:racket-like-expr)
#:binding (scope (bind-syntaxes v e) b)
```


## An alternative: optional ellipses

Should ellipses be mandatory? This PR includes a static check that ensures all variables are properly ellipsized. However, it would also be possible to make ellipses optional and default to the current inferred behavior when they are not present. This would ensure all binding structures are possible to specify without requiring ellipses all the time. We could still statically check that there are not too many ellipses, since that would cause problems, but with too few ellipses, the old behavior of inferred binding structure would be used.

One subtle issue with this more implicit design is `nest`. In the implicit design, it seems most consistent with the behavior of the other binding forms that we be able to write what are now `nest` and `nest-one` in exactly the same way, relying on the ellipsis depth of the pattern variable binding to choose between the meanings. So a let* with a sequence of binding pairs:

```
(my-let* (b:binding-pair ...) body:my-expr)
#:binding (nest b body)
```

would have the same binding rule as a form with a single such binding pair:

```
(my-let*1 b:binding-pair body:my-expr)
#:binding (nest b body)
```

In the first case, nest is folding over a sequence, whereas in the second case it is nesting a single element. This implicit difference might be confusing.
