### PR TITLE
get-racket-referenced-identifiers emits syntax-quoted identifiers

### DIFF
--- a/private/runtime/binding-operations.rkt
+++ b/private/runtime/binding-operations.rkt
@@ -11,7 +11,7 @@
          syntax/parse
          syntax/id-table
          "../ee-lib/main.rkt"
-         (for-template "./compile.rkt"))
+         (for-template racket/base "./compile.rkt"))
 
 ;; Currently we use this as the notion of identifier equality:
 (define (identifier=? x y) (free-identifier=? (compiled-from x) (compiled-from y)))
@@ -179,9 +179,12 @@
 
 (define recording-reference-compiler
   (make-variable-like-reference-compiler
-   (lambda (x) (symbol-set-add! (current-referenced-vars) x) x)
+   ;; emit syntax instead of raw reference.
+   ;; this is necessary for languages that don't emit bindings for
+   ;; racket-reference-able identifiers.
+   (lambda (x) (symbol-set-add! (current-referenced-vars) x) #`#'#,x)
    (lambda (e)
      (syntax-parse e
        [(set! x _)
         (symbol-set-add! (current-referenced-vars) #'x)
-        #'x]))))
+        #'#'x]))))

--- a/tests/racket-references.rkt
+++ b/tests/racket-references.rkt
@@ -16,6 +16,8 @@
     #:binding (scope (bind x) e)
     (let/c x:c-var e:my-expr)
     #:binding (scope (bind x) e)
+    (let/no-binding x:a-var e:my-expr)
+    #:binding (scope (bind x) e)
     (rkt e:racket-expr))
   (host-interface/expression
    (my-dsl e:my-expr)
@@ -23,9 +25,11 @@
 
 (define-syntax compile-expr
   (syntax-parser
-    #:datum-literals (let/a let/b let/c rkt)
+    #:datum-literals (let/a let/b let/c let/no-binding rkt)
     [(_ ((~or let/a let/b let/c) x:id e:expr))
      #'(let ([x 1]) (compile-expr e))]
+    [(_ (let/no-binding x:id e:expr))
+     #'(compile-expr e)]
     [(_ (rkt e:expr))
      (define/syntax-parse (x ...) (get-racket-referenced-identifiers (a-var b-var)
                                     #'e))
@@ -50,3 +54,5 @@
                                        (let/b z
                                          (rkt (+ x y z)))))))
               (seteq 'y 'z))
+(check-equal? (my-dsl (let/no-binding x (rkt (+ x x))))
+              '(x))


### PR DESCRIPTION
fixes #64