### PR TITLE
export binding-identifiers

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -51,6 +51,7 @@
 
           compiled-identifier=?
           free-identifiers
+          binding-identifiers
           alpha-equivalent?
           get-racket-referenced-identifiers))
 

--- a/private/runtime/binding-operations.rkt
+++ b/private/runtime/binding-operations.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (provide free-identifiers
+         binding-identifiers
          alpha-equivalent?
          get-racket-referenced-identifiers
          (rename-out [identifier=? compiled-identifier=?]))
@@ -48,6 +49,10 @@
   (define refs (deduplicate-references (all-references stx allow-host?)))
   (define binders (all-binders stx allow-host?))
   (subtract-identifiers refs binders))
+
+;; Syntax, [#:allow-host? Boolean] -> (ListOf Identifier)
+(define (binding-identifiers stx #:allow-host? [allow-host? #f])
+  (all-binders stx allow-host?))
 
 ;; Syntax, Boolean -> (ListOf Identifier)
 ;; The result list may have duplicates.

--- a/scribblings/reference/compiling.scrbl
+++ b/scribblings/reference/compiling.scrbl
@@ -220,6 +220,12 @@ Get a DSL expression's free identifiers (deduplicated).
 
 Host expressions currently are not supported.
 
+@defproc[(binding-identifiers [stx syntax?] [#:allow-host? allow-host? boolean? #f]) (listof identifier?)]
+
+Get a DSL expression's binding identifiers.
+
+Host expressions currently are not supported.
+
 @defproc[(alpha-equivalent? [stx-a syntax?] [stx-b syntax?] [#:allow-host? allow-host? boolean? #f]) boolean?]
 
 Returns @racket[#t] if the two DSL expressions are alpha-equivalent, @racket[#f] otherwise.

--- a/tests/binding-operations.rkt
+++ b/tests/binding-operations.rkt
@@ -10,7 +10,7 @@
    v:var
    (+ e1:expr e2:expr)
    (host e:racket-expr)
-   
+
    (lambda (x:var) e:expr)
    #:binding (scope (bind x) e)
 
@@ -26,8 +26,11 @@
 (syntax-spec
  (host-interface/expression
   (expr/free-vars-as-symbols e:expr)
+  #`(list #,@(map (lambda (id) #`'#,id) (free-identifiers #'e))))
 
-  #`(list #,@(map (lambda (id) #`'#,id) (free-identifiers #'e)))))
+ (host-interface/expression
+  (expr/binding-vars-as-symbols e:expr)
+  #`(list #,@(map (lambda (id) #`'#,id) (binding-identifiers #'e)))))
 
 
 (define-var x)
@@ -42,6 +45,16 @@
         (+ y z)))
    z))
  '(x z))
+
+(check-equal?
+ (expr/binding-vars-as-symbols
+  (lambda (w)
+    (+
+     (+ x
+        (lambda (y)
+          (+ y z)))
+     z)))
+ '(w y))
 
 (check-exn
  #rx"free-identifiers: can't enter a #%host-expression"


### PR DESCRIPTION
Used in QEA DSL for extracting binding identifiers from match pattern and building lookup table.