### PR TITLE
Fix running tests without the package being installed.

### DIFF
--- a/tests/dsls/matthews-findler/lump-inferred.rkt
+++ b/tests/dsls/matthews-findler/lump-inferred.rkt
@@ -4,12 +4,12 @@
          (for-space ml (all-defined-out)))
 
 (require
-  syntax-spec-dev
+  "../../../testing.rkt"
 
   (for-syntax
     racket/base 
     syntax/parse
-    (only-in syntax-spec-dev/private/ee-lib/main lookup in-space)))
+    (only-in "../../../private/ee-lib/main.rkt" lookup in-space)))
 
 (syntax-spec
   (binding-class ml-var

--- a/tests/dsls/matthews-findler/lump.rkt
+++ b/tests/dsls/matthews-findler/lump.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(require syntax-spec-dev (for-syntax racket/base syntax/parse))
+(require "../../../testing.rkt" (for-syntax racket/base syntax/parse))
 
 (syntax-spec
   (binding-class ml-var #:binding-space ml)

--- a/tests/dsls/matthews-findler/ml.rkt
+++ b/tests/dsls/matthews-findler/ml.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(require syntax-spec-dev (for-syntax racket/base syntax/parse))
+(require "../../../testing.rkt" (for-syntax racket/base syntax/parse))
 
 (syntax-spec
   (binding-class ml-var #:binding-space ml)


### PR DESCRIPTION
Before:

```
raco test: (submod (file "tests/dsls/matthews-findler/lump-inferred.rkt") test)
lump-inferred.rkt:7:2: collection not found
  for module path: syntax-spec-dev
  collection: "syntax-spec-dev"
  in collection directories:
   /home/joe/.local/share/racket/8.16/collects
   /home/joe/racket/collects/
   ... [215 additional linked and package directories]
  location...:
   lump-inferred.rkt:7:2
  context...:
   /home/joe/racket/share/pkgs/compiler-lib/compiler/commands/test.rkt:98:2
   body of (submod "/home/joe/racket/share/pkgs/compiler-lib/compiler/commands/test.rkt" process)
   body of top-level
lump-inferred.rkt: raco test: non-zero exit: 1
raco test: (submod (file "tests/dsls/matthews-findler/lump.rkt") test)
lump.rkt:3:9: collection not found
  for module path: syntax-spec-dev
  collection: "syntax-spec-dev"
  in collection directories:
   /home/joe/.local/share/racket/8.16/collects
   /home/joe/racket/collects/
   ... [215 additional linked and package directories]
  location...:
   lump.rkt:3:9
  context...:
   /home/joe/racket/share/pkgs/compiler-lib/compiler/commands/test.rkt:98:2
   body of (submod "/home/joe/racket/share/pkgs/compiler-lib/compiler/commands/test.rkt" process)
   body of top-level
lump.rkt: raco test: non-zero exit: 1
raco test: (submod (file "tests/dsls/matthews-findler/ml.rkt") test)
ml.rkt:3:9: collection not found
  for module path: syntax-spec-dev
  collection: "syntax-spec-dev"
  in collection directories:
   /home/joe/.local/share/racket/8.16/collects
   /home/joe/racket/collects/
   ... [215 additional linked and package directories]
  location...:
   ml.rkt:3:9
  context...:
   /home/joe/racket/share/pkgs/compiler-lib/compiler/commands/test.rkt:98:2
   body of (submod "/home/joe/racket/share/pkgs/compiler-lib/compiler/commands/test.rkt" process)
   body of top-level
ml.rkt: raco test: non-zero exit: 1
```

After:

```
raco test: (submod (file "tests/dsls/matthews-findler/lump-inferred.rkt") test)
  13 tests/dsls/matthews-findler/lump-inferred.rkt
13 tests passed

$ racket tests/dsls/matthews-findler/lump.rkt 
0
$ racket tests/dsls/matthews-findler/ml.rkt 
0
```
