### PR TITLE
doc: mention that v3 is compatible with Racket versions ≥ 8.10

### DIFF
--- a/scribblings/reference/versions.scrbl
+++ b/scribblings/reference/versions.scrbl
@@ -18,6 +18,8 @@ With this change the new @tt{nest} syntax accomplishes the behavior of the old @
 
 @tech{Reference compilers} are now specified as part of @tech[#:key "binding classes"]{binding class} declarations, rather than with @tt{with-reference-compilers}. If you previously used @tt{with-reference-compilers} to create reference compilers with contextual behavior, you can typically use @tech/reference{syntax parameters} to accomplish the same with the new design.
 
+This version drops support for Racket versions earlier than 8.10.
+
 @section[#:style '(unnumbered)]{Version 2}
 
 Some forms were renamed:


### PR DESCRIPTION
Older versions of Racket (Qi currently supports ≥ 8.5) encounter this error:

```
raco setup: 1 making: <pkgs>/syntax-spec-v3/tests
/home/runner/.local/share/racket/8.9-bc/pkgs/syntax-spec-v3/private/syntax/interface.rkt:106:63: descr.str: attribute contains non-syntax value
  value: #f
  in: descr.str
  compilation context...:
   /home/runner/.local/share/racket/8.9-bc/pkgs/syntax-spec-v3/tests/binding-operations.rkt
  location...:
   /home/runner/.local/share/racket/8.9-bc/pkgs/syntax-spec-v3/private/syntax/interface.rkt:106:63
  context...:
   dots-loop
   /home/runner/.local/share/racket/8.9-bc/pkgs/syntax-spec-v3/private/syntax/interface.rkt:56:8: for-loop
   dots-loop
   /usr/share/racket/collects/syntax/wrap-modbeg.rkt:46:4: do-wrapping-module-begin
   /usr/share/racket/collects/compiler/private/cm-minimal.rkt:686:0: compile-zo*
   /usr/share/racket/collects/compiler/private/cm-minimal.rkt:452:15
   /usr/share/racket/collects/compiler/private/cm-minimal.rkt:412:0: maybe-compile-zo
   /usr/share/racket/collects/compiler/private/cm-minimal.rkt:210:0: compile-root
   /usr/share/racket/collects/compiler/private/cm-minimal.rkt:105:4
   /usr/share/racket/collects/setup/parallel-build.rkt:332:9
   /usr/share/racket/collects/setup/parallel-do.rkt:456:25
   /usr/share/racket/collects/setup/parallel-do.rkt:442:20: loop
```

(for the full build output with various versions of Racket, please see the history of CI results for [this PR](https://github.com/drym-org/qi/pull/202))

Assuming dropping support for <= 8.9 is intentional, this PR documents that in the release notes.
